### PR TITLE
Timestep Changes

### DIFF
--- a/src/event/BehaviorChanges.cpp
+++ b/src/event/BehaviorChanges.cpp
@@ -51,7 +51,7 @@ namespace Event {
             (Person::BehaviorClassification)this->getDecision(probs);
         // 3. If the drawn state differs from the current state, change the
         // bools in BehaviorState to match
-        person->updateBehavior(toBC);
+        person->updateBehavior(toBC, this->getCurrentTimestep());
     }
 
     std::vector<double>

--- a/src/event/Clearance.cpp
+++ b/src/event/Clearance.cpp
@@ -33,7 +33,7 @@ namespace Event {
         if (doesNotClear) {
             return;
         }
-        person->clearHCV();
+        person->clearHCV(this->getCurrentTimestep());
     }
 
     std::vector<double> Clearance::getClearanceProb() {

--- a/src/event/DiseaseProgression.cpp
+++ b/src/event/DiseaseProgression.cpp
@@ -35,6 +35,6 @@ namespace Event {
         // 3. Randomly draw the state to transition to
         Person::LiverState toLS = (Person::LiverState)this->getDecision(probs);
         // 4. Transition to the new state
-        person->updateLiver(toLS);
+        person->updateLiver(toLS, this->getCurrentTimestep());
     }
 } // namespace Event

--- a/src/event/Infections.cpp
+++ b/src/event/Infections.cpp
@@ -30,7 +30,7 @@ namespace Event {
         if (!value) {
             return;
         }
-        person->infect();
+        person->infect(this->getCurrentTimestep());
     }
 
     std::vector<double>

--- a/src/event/Treatment.cpp
+++ b/src/event/Treatment.cpp
@@ -32,12 +32,13 @@ namespace Event {
     bool
     Treatment::isEligible(std::shared_ptr<Person::Person> const person) const {
         Person::LiverState liverState = person->getLiverState();
-        int timeSinceLinked = person->getTimeLinkChange();
+        int timeSinceLinked = person->getTimeOfLinkChange();
         Person::BehaviorClassification behavior =
             person->getBehaviorClassification();
         int timeBehaviorChange = person->getTimeBehaviorChange();
         if (!isEligibleFibrosisStage(liverState) ||
-            (timeSinceLinked > eligibleTimeSinceLinked) ||
+            ((this->getCurrentTimestep() - timeSinceLinked) >
+             eligibleTimeSinceLinked) ||
             (behavior == Person::BehaviorClassification::INJECTION) ||
             (behavior == Person::BehaviorClassification::FORMER_INJECTION &&
              timeBehaviorChange < eligibleTimeBehaviorChange)) {

--- a/src/event/VoluntaryRelinking.cpp
+++ b/src/event/VoluntaryRelinking.cpp
@@ -27,7 +27,7 @@ namespace Event {
         this->generatorMutex.unlock();
 
         if (person->getLinkState() != Person::LinkageState::UNLINKED ||
-            (this->getCurrentTimestep() - person->getTimeLinkChange()) >
+            (this->getCurrentTimestep() - person->getTimeOfLinkChange()) >
                 this->voluntaryRelinkDuration ||
             !relink) {
             return; // if linked or never linked OR too long since last linked

--- a/src/person/Person.cpp
+++ b/src/person/Person.cpp
@@ -11,13 +11,13 @@ namespace Person {
         }
     }
 
-    void Person::infect() {
+    void Person::infect(int timestep) {
         // cannot be multiply infected
         if (this->infectionStatus.hepcState != HEPCState::NONE) {
             return;
         }
         this->infectionStatus.hepcState = HEPCState::ACUTE;
-        this->infectionStatus.timeSinceHEPCStateChange = 0;
+        this->infectionStatus.timeHEPCStateChanged = timestep;
         this->seropositivity = true;
 
         if (this->infectionStatus.liverState != LiverState::NONE) {
@@ -25,28 +25,29 @@ namespace Person {
         }
         // once infected, immediately enter F0
         this->infectionStatus.liverState = LiverState::F0;
-        this->infectionStatus.timeSinceLiverStateChange = 0;
+        this->infectionStatus.timeLiverStateChanged = timestep;
     }
 
-    void Person::clearHCV() {
+    void Person::clearHCV(int timestep) {
         // cannot clear if the person is not infected
         if (this->infectionStatus.hepcState == HEPCState::NONE) {
             return;
         }
         this->infectionStatus.hepcState = HEPCState::NONE;
-        this->infectionStatus.timeSinceHEPCStateChange = 0;
+        this->infectionStatus.timeHEPCStateChanged = timestep;
     }
 
-    void Person::updateLiver(const LiverState &ls) {
+    void Person::updateLiver(const LiverState &ls, int timestep) {
         // nothing to do -- can only advance liver state
         if (ls <= this->infectionStatus.liverState) {
             return;
         }
         this->infectionStatus.liverState = ls;
-        this->infectionStatus.timeSinceLiverStateChange = 0;
+        this->infectionStatus.timeLiverStateChanged = timestep;
     }
 
-    void Person::updateBehavior(const BehaviorClassification &bc) {
+    void Person::updateBehavior(const BehaviorClassification &bc,
+                                int timestep) {
         // nothing to do -- cannot go back to NEVER
         if (bc == this->behaviorDetails.behaviorClassification ||
             bc == BehaviorClassification::NEVER) {
@@ -55,7 +56,7 @@ namespace Person {
         // count for timeSinceActive if switching from active to non-active use
         if ((bc == BehaviorClassification::FORMER_NONINJECTION) ||
             (bc == BehaviorClassification::FORMER_INJECTION)) {
-            this->behaviorDetails.timeSinceActive = 0;
+            this->behaviorDetails.timeLastActive = timestep;
         }
         // update the behavior classification
         this->behaviorDetails.behaviorClassification = bc;

--- a/src/person/include/Person.hpp
+++ b/src/person/include/Person.hpp
@@ -149,34 +149,34 @@ namespace Person {
     struct InfectionStatus {
         HEPCState hepcState = HEPCState::NONE;
         LiverState liverState = LiverState::NONE;
-        int timeSinceHEPCStateChange = 0;
-        int timeSinceLiverStateChange = 0;
+        int timeHEPCStateChanged = 0;
+        int timeLiverStateChanged = 0;
     };
 
     /// @brief Attributes describing drug use behavior
     struct BehaviorDetails {
         BehaviorClassification behaviorClassification =
             BehaviorClassification::NEVER;
-        int timeSinceActive = -1;
+        int timeLastActive = -1;
     };
 
     /// @brief Attributes describing Linkage
     struct LinkageDetails {
         LinkageState linkState = LinkageState::NEVER;
-        int timeLinkChange = -1;
+        int timeOfLinkChange = -1;
         LinkageType linkType = LinkageType::BACKGROUND;
     };
 
     /// @brief Attributes describing MOUD status
     struct MOUDDetails {
         MOUD moudState = MOUD::NONE;
-        int timeOnMoud = -1;
+        int timeStartedMoud = -1;
     };
 
     /// @brief Attributes describing pregnancy
     struct PregnancyDetails {
         PregnancyState pregnancyState = PregnancyState::NEVER;
-        int timeSpentPregnant = -1;
+        int timeOfPregnancyChange = -1;
         int infantCount = 0;
         int miscarriageCount = 0;
     };
@@ -184,7 +184,7 @@ namespace Person {
     /// @brief Person attributes describing clinically assessed liver stage
     struct StagingDetails {
         MeasuredLiverState measuredLiverState = MeasuredLiverState::NONE;
-        int timeSinceStaging = -1;
+        int timeOfLastStaging = -1;
     };
 
     /// @brief Class describing a Person
@@ -226,18 +226,22 @@ namespace Person {
         void grow();
 
         /// @brief Infect the person
-        void infect();
+        /// @param timestep Current simulation timestep
+        void infect(int timestep);
 
         /// @brief Clear of HCV
-        void clearHCV();
+        /// @param timestep Current simulation timestep
+        void clearHCV(int timestep);
 
         /// @brief Update the Liver State
         /// @param ls Current Liver State
-        void updateLiver(const LiverState &ls);
+        /// @param timestep Current simulation timestep
+        void updateLiver(const LiverState &ls, int timestep);
 
         /// @brief Update Opioid Use Behavior Classification
         /// @param bc The intended resultant BehaviorClassification
-        void updateBehavior(const BehaviorClassification &bc);
+        /// @param timestep Current simulation timestep
+        void updateBehavior(const BehaviorClassification &bc, int timestep);
 
         /// @brief Diagnose somebody's fibrosis
         /// @return Fibrosis state that is diagnosed
@@ -270,7 +274,7 @@ namespace Person {
         void unlink(const int timestep) {
             if (this->linkStatus.linkState == LinkageState::LINKED) {
                 this->linkStatus.linkState = LinkageState::UNLINKED;
-                this->linkStatus.timeLinkChange = timestep;
+                this->linkStatus.timeOfLinkChange = timestep;
             }
         }
 
@@ -279,7 +283,7 @@ namespace Person {
         /// @param linkType The linkage type the Person recieves
         void link(int timestep, LinkageType linkType) {
             this->linkStatus.linkState = LinkageState::LINKED;
-            this->linkStatus.timeLinkChange = timestep;
+            this->linkStatus.timeOfLinkChange = timestep;
             this->linkStatus.linkType = linkType;
         }
 
@@ -338,19 +342,19 @@ namespace Person {
         /// @brief Getter for time since active drug use
         /// @return Time since the person left an active drug use state
         int getTimeBehaviorChange() {
-            return this->behaviorDetails.timeSinceActive;
+            return this->behaviorDetails.timeLastActive;
         }
 
-        /// @brief Getter for Time since HCV Change
+        /// @brief Getter for timestep in which HCV last changed
         /// @return Time Since HCV Change
-        int getTimeSinceHEPCStateChange() const {
-            return this->infectionStatus.timeSinceHEPCStateChange;
+        int getTimeHEPCStateChanged() const {
+            return this->infectionStatus.timeHEPCStateChanged;
         }
 
         /// @brief Getter for Time since Liver State Change
         /// @return Time Since Liver State Change
-        int getTimeSinceLiverStateChange() const {
-            return this->infectionStatus.timeSinceLiverStateChange;
+        int getTimeLiverStateChanged() const {
+            return this->infectionStatus.timeLiverStateChanged;
         }
 
         /// @brief Getter for Seropositivity
@@ -367,10 +371,10 @@ namespace Person {
         /// @return Link State
         LinkageState getLinkState() const { return this->linkStatus.linkState; }
 
-        /// @brief Getter for Time Link Change
+        /// @brief Getter for Timestep in which linkage changed
         /// @return Time Link Change
-        int getTimeLinkChange() const {
-            return this->linkStatus.timeLinkChange;
+        int getTimeOfLinkChange() const {
+            return this->linkStatus.timeOfLinkChange;
         }
 
         /// @brief Getter for Linkage Type
@@ -378,6 +382,7 @@ namespace Person {
         LinkageType getLinkageType() const { return this->linkStatus.linkType; }
 
         /// @brief Get the person's numeric ID
+        /// @return Person's numeric ID
         int getID() const { return this->id; }
 
         /// @brief
@@ -386,6 +391,9 @@ namespace Person {
             return this->incompleteTreatment;
         }
 
+        /// @brief
+        /// @param incompleteTreatment
+        /// @return
         void setIncompleteTreatment(bool incompleteTreatment) {
             this->incompleteTreatment = incompleteTreatment;
         }
@@ -396,10 +404,10 @@ namespace Person {
             return this->pregnancyDetails.pregnancyState;
         }
 
-        /// @brief Getter for time spent pregnant
-        /// @return Time spent pregnant
-        int getTimeSpentPregnant() {
-            return this->pregnancyDetails.timeSpentPregnant;
+        /// @brief Getter for timestep in which last pregnancy change happened
+        /// @return Time pregnancy state last changed
+        int getTimeOfPregnancyChange() {
+            return this->pregnancyDetails.timeOfPregnancyChange;
         }
 
         /// @brief Getter for number of infants
@@ -418,19 +426,20 @@ namespace Person {
             return this->stagingDetails.measuredLiverState;
         }
 
-        /// @brief Getter for time since last liver staging
-        /// @return Time since person's last liver staging
-        int getTimeSinceLiverStaging() {
-            return this->stagingDetails.timeSinceStaging;
+        /// @brief Getter for timestep in which the last liver staging test
+        /// happened
+        /// @return Timestep of person's last liver staging
+        int getTimeOfLastStaging() {
+            return this->stagingDetails.timeOfLastStaging;
         }
 
         /// @brief Getter for MOUD State
         /// @return MOUD State
         MOUD getMoudState() { return this->moudDetails.moudState; }
 
-        /// @brief Getter for time spent on MOUD
+        /// @brief Getter for timestep in which MOUD was started
         /// @return Time spent on MOUD
-        int getTimeOnMoud() { return this->moudDetails.timeOnMoud; }
+        int getTimeStartedMoud() { return this->moudDetails.timeStartedMoud; }
     };
 } // namespace Person
 #endif

--- a/tests/EventTest.cpp
+++ b/tests/EventTest.cpp
@@ -68,7 +68,7 @@ TEST_F(EventTest, BehaviorChange) {
 TEST_F(EventTest, Clearance) {
     Data::DataTable table;
     Event::Clearance clearance(simulation->getGenerator(), table);
-    livingPopulation[0]->infect();
+    livingPopulation[0]->infect(0);
     clearance.execute(livingPopulation, 1);
     EXPECT_EQ(Person::HEPCState::ACUTE, livingPopulation[0]->getHEPCState());
 }
@@ -87,7 +87,7 @@ TEST_F(EventTest, DiseaseProgression) {
     Data::DataTable table;
     Event::DiseaseProgression diseaseProgression(simulation->getGenerator(),
                                                  table);
-    livingPopulation[0]->infect();
+    livingPopulation[0]->infect(0);
     diseaseProgression.execute(livingPopulation, 1);
     EXPECT_EQ(Person::LiverState::F0, livingPopulation[0]->getLiverState());
 }

--- a/tests/PersonTest.cpp
+++ b/tests/PersonTest.cpp
@@ -62,20 +62,20 @@ TEST(PersonGrowth, DeathAge) {
 
 TEST(PersonInfect, InfectNormally) {
     Person::Person person;
-    person.infect();
+    person.infect(0);
     EXPECT_EQ(person.getHEPCState(), Person::HEPCState::ACUTE);
-    EXPECT_EQ(person.getTimeSinceHEPCStateChange(), 0);
+    EXPECT_EQ(person.getTimeHEPCStateChanged(), 0);
     EXPECT_TRUE(person.getSeropositivity());
 
     EXPECT_EQ(person.getLiverState(), Person::LiverState::F0);
-    EXPECT_EQ(person.getTimeSinceLiverStateChange(), 0);
+    EXPECT_EQ(person.getTimeLiverStateChanged(), 0);
 }
 
 TEST(PersonInfect, ResistMultiHCVInfect) {
     Person::Person person;
     person.diagnoseHEPC(5);
     person.setSeropositivity(false);
-    person.infect();
+    person.infect(0);
     EXPECT_EQ(person.getHEPCState(), Person::HEPCState::ACUTE);
     EXPECT_FALSE(person.getSeropositivity());
 }
@@ -83,7 +83,7 @@ TEST(PersonInfect, ResistMultiHCVInfect) {
 TEST(PersonInfect, ResistMultiFibrosisInfect) {
     Person::Person person;
     person.diagnoseLiver(5);
-    person.infect();
+    person.infect(0);
     EXPECT_EQ(person.getHEPCState(), Person::HEPCState::ACUTE);
     EXPECT_EQ(person.getLiverState(), Person::LiverState::F0);
 }
@@ -94,7 +94,7 @@ TEST(PersonLink, LinkNormally) {
     Person::LinkageType linkType = Person::LinkageType::BACKGROUND;
     person.link(timestep, linkType);
     EXPECT_EQ(person.getLinkState(), Person::LinkageState::LINKED);
-    EXPECT_EQ(person.getTimeLinkChange(), timestep);
+    EXPECT_EQ(person.getTimeOfLinkChange(), timestep);
     EXPECT_EQ(person.getLinkageType(), linkType);
 }
 
@@ -105,13 +105,13 @@ TEST(PersonUnlink, UnlinkNormally) {
     int unlinkTimestep = 10;
     person.unlink(unlinkTimestep);
     EXPECT_EQ(person.getLinkState(), Person::LinkageState::UNLINKED);
-    EXPECT_EQ(person.getTimeLinkChange(), unlinkTimestep);
+    EXPECT_EQ(person.getTimeOfLinkChange(), unlinkTimestep);
 }
 
 TEST(PersonUnlink, UnableToUnlink) {
     Person::Person person;
     person.unlink(10);
-    EXPECT_EQ(person.getTimeLinkChange(), -1);
+    EXPECT_EQ(person.getTimeOfLinkChange(), -1);
 }
 
 TEST(PersonBehavior, BehaviorUpdate) {
@@ -120,16 +120,16 @@ TEST(PersonBehavior, BehaviorUpdate) {
     EXPECT_EQ(person.getBehaviorClassification(),
               Person::BehaviorClassification::NEVER);
     // change to the NONINJECTION opioid usage state
-    person.updateBehavior(Person::BehaviorClassification::NONINJECTION);
+    person.updateBehavior(Person::BehaviorClassification::NONINJECTION, 0);
     EXPECT_EQ(person.getBehaviorClassification(),
               Person::BehaviorClassification::NONINJECTION);
 }
 
 TEST(PersonBehavior, InvalidTransition) {
     Person::Person person;
-    person.updateBehavior(Person::BehaviorClassification::NONINJECTION);
+    person.updateBehavior(Person::BehaviorClassification::NONINJECTION, 0);
     // cannot transition back to NEVER
-    person.updateBehavior(Person::BehaviorClassification::NEVER);
+    person.updateBehavior(Person::BehaviorClassification::NEVER, 0);
     EXPECT_EQ(person.getBehaviorClassification(),
               Person::BehaviorClassification::NONINJECTION);
 }
@@ -139,14 +139,14 @@ TEST(PersonLiver, LiverUpdate) {
     // people start in the NONE state
     EXPECT_EQ(person.getLiverState(), Person::LiverState::NONE);
     // change to a higher disease state
-    person.updateLiver(Person::LiverState::F4);
+    person.updateLiver(Person::LiverState::F4, 0);
     EXPECT_EQ(person.getLiverState(), Person::LiverState::F4);
 }
 
 TEST(PersonLiver, InvalidTransition) {
     Person::Person person;
-    person.updateLiver(Person::LiverState::F4);
+    person.updateLiver(Person::LiverState::F4, 0);
     // cannot transition to a lower disease state
-    person.updateLiver(Person::LiverState::F3);
+    person.updateLiver(Person::LiverState::F3, 0);
     EXPECT_EQ(person.getLiverState(), Person::LiverState::F4);
 }


### PR DESCRIPTION
Changes attributes of `Person` from being "since" (requiring updates every timestep) to referencing the timestep of the last change (so that we just calculate the time since the event using the current timestep, from within events).

Note that this changed the outcome of the BehaviorChanges test, due to how changes to `Person` seem to change the random number generator behavior.