### PR TITLE
Adding optional birth_cohort multiplier for background screening

### DIFF
--- a/src/person/include/Person.hpp
+++ b/src/person/include/Person.hpp
@@ -55,6 +55,7 @@ namespace Person {
         Utility utility;
         std::pair<double, double> totalUtilities = {0, 0};
         Cost::CostTracker costs;
+        bool boomerClassification = false;
 
     public:
         /// @brief Person age in months
@@ -516,6 +517,12 @@ namespace Person {
         /// @brief Getter for the Person's costs
         /// @return Cost::CostTracker containing this person's costs
         Cost::CostTracker getCosts() const { return this->costs; }
+
+        bool isBoomer() { return this->boomerClassification; }
+
+        void setBoomerClassification(bool status) {
+            this->boomerClassification = status;
+        }
     };
 } // namespace Person
 #endif


### PR DESCRIPTION
As the title says:
- Added an optional parameter check for the birth_cohort multiplier in background screening