### PR TITLE
Recent Screening Multiplier

### DIFF
--- a/src/event/Linking.cpp
+++ b/src/event/Linking.cpp
@@ -141,7 +141,7 @@ namespace event {
             bool recently_screened =
                 (person->GetTimeSinceLastScreening() <= recent_screen_cutoff);
             // apply the multiplier to recently screened persons
-            if (recently_screened) {
+            if (recently_screened && (prob < 1)) {
                 prob = ApplyMultiplier(prob, recent_screen_multiplier);
             }
 

--- a/tests/src/eventtests/LinkingTest.cpp
+++ b/tests/src/eventtests/LinkingTest.cpp
@@ -301,7 +301,66 @@ TEST_F(LinkingTest, RecentScreen) {
     std::vector<double> expected_probs = {0.96};
     // Expectations
     EXPECT_CALL(*decider, GetDecision(expected_probs)).Times(1);
-    EXPECT_CALL(*testPerson, Link(person::LinkageType::BACKGROUND)).Times(1);
+
+    // Running Test
+    std::shared_ptr<event::Event> event = efactory.create("Linking", event_dm);
+    event->Execute(testPerson, event_dm, decider);
+}
+
+TEST_F(LinkingTest, RecentScreenCutoff) {
+    // Person Setup
+    ON_CALL(*testPerson, GetHCV()).WillByDefault(Return(person::HCV::ACUTE));
+    ON_CALL(*testPerson, IsIdentifiedAsHCVInfected())
+        .WillByDefault(Return(true));
+    ON_CALL(*testPerson, GetLinkState())
+        .WillByDefault(Return(person::LinkageState::UNLINKED));
+    ON_CALL(*testPerson, GetLinkageType())
+        .WillByDefault(Return(person::LinkageType::BACKGROUND));
+    ON_CALL(*testPerson, GetAge()).WillByDefault(Return(300));
+    ON_CALL(*testPerson, GetSex()).WillByDefault(Return(person::Sex::MALE));
+    ON_CALL(*testPerson, GetBehavior())
+        .WillByDefault(Return(person::Behavior::NEVER));
+    ON_CALL(*testPerson, GetPregnancyState())
+        .WillByDefault(Return(person::PregnancyState::NA));
+    ON_CALL(*testPerson, GetTimeSinceLastScreening()).WillByDefault(Return(1));
+
+    // Data Setup
+    ON_CALL(*event_dm, GetFromConfig("linking.intervention_cost", _))
+        .WillByDefault(DoAll(SetArgReferee<1>("0.0"), Return(0)));
+    ON_CALL(*event_dm, GetFromConfig("linking.false_positive_test_cost", _))
+        .WillByDefault(DoAll(SetArgReferee<1>("0.0"), Return(0)));
+    ON_CALL(*event_dm, GetFromConfig("linking.recent_screen_multiplier", _))
+        .WillByDefault(DoAll(SetArgReferee<1>("2.00"), Return(0)));
+    ON_CALL(*event_dm, GetFromConfig("linking.recent_screen_cutoff", _))
+        .WillByDefault(DoAll(SetArgReferee<1>("0"), Return(0)));
+    ON_CALL(*event_dm, GetFromConfig("cost.discounting_rate", _))
+        .WillByDefault(DoAll(SetArgReferee<1>("0.0"), Return(0)));
+
+    // Background Link Setup
+    double link_prob = 0.8;
+    Utils::tuple_4i tup_4i = std::make_tuple(25, 0, 0, -1);
+    std::unordered_map<Utils::tuple_4i, double, Utils::key_hash_4i,
+                       Utils::key_equal_4i>
+        bstorage;
+    bstorage[tup_4i] = link_prob;
+    ON_CALL(*event_dm, SelectCustomCallback(BACKGROUND_LINK_QUERY, _, _, _))
+        .WillByDefault(DoAll(SetArg2ToUM_T4I_Double(&bstorage), Return(0)));
+
+    // Intervention Link Setup
+    link_prob = 0.0;
+    std::unordered_map<Utils::tuple_4i, double, Utils::key_hash_4i,
+                       Utils::key_equal_4i>
+        istorage;
+    istorage[tup_4i] = link_prob;
+    ON_CALL(*event_dm, SelectCustomCallback(INTERVENTION_LINK_QUERY, _, _, _))
+        .WillByDefault(DoAll(SetArg2ToUM_T4I_Double(&istorage), Return(0)));
+
+    // Decider Setup
+    ON_CALL(*decider, GetDecision(_)).WillByDefault(Return(0));
+
+    std::vector<double> expected_probs = {0.8};
+    // Expectations
+    EXPECT_CALL(*decider, GetDecision(expected_probs)).Times(1);
 
     // Running Test
     std::shared_ptr<event::Event> event = efactory.create("Linking", event_dm);


### PR DESCRIPTION
This PR implements the changes to `Linking` mentioned in our meeting yesterday.

I'm not sure how to write tests for this, since the pRNG is mocked and doesn't actually draw values. I'd *love* suggestions, if you have any, @MJC598.