### PR TITLE
Hotfix Behavior Cost and Utilities

### DIFF
--- a/src/event/BehaviorChanges.cpp
+++ b/src/event/BehaviorChanges.cpp
@@ -62,21 +62,21 @@ private:
     };
 
     using costmap_t =
-        std::unordered_map<Utils::tuple_3i, struct cost_util,
-                           Utils::key_hash_3i, Utils::key_equal_3i>;
+        std::unordered_map<Utils::tuple_2i, struct cost_util,
+                           Utils::key_hash_2i, Utils::key_equal_2i>;
     costmap_t cost_data;
 
     std::string CostSQL() const {
-        return "SELECT age_years, gender, drug_behavior, cost, utility FROM "
+        return "SELECT gender, drug_behavior, cost, utility FROM "
                "behavior_impacts;";
     }
 
     static int callback_costs(void *storage, int count, char **data,
                               char **columns) {
-        Utils::tuple_3i tup = std::make_tuple(
-            std::stoi(data[0]), std::stoi(data[1]), std::stoi(data[2]));
-        struct cost_util cu = {Utils::stod_positive(data[3]),
-                               Utils::stod_positive(data[4])};
+        Utils::tuple_2i tup =
+            std::make_tuple(std::stoi(data[0]), std::stoi(data[1]));
+        struct cost_util cu = {Utils::stod_positive(data[2]),
+                               Utils::stod_positive(data[3])};
         (*((costmap_t *)storage))[tup] = cu;
         return 0;
     }
@@ -84,10 +84,9 @@ private:
     void calculateCostAndUtility(
         std::shared_ptr<person::PersonBase> person,
         std::shared_ptr<datamanagement::DataManagerBase> dm) {
-        int age = (int)(person->GetAge() / 12.0);
         int gender = ((int)person->GetSex());
         int behavior = ((int)person->GetBehavior());
-        Utils::tuple_3i tup = std::make_tuple(age, gender, behavior);
+        Utils::tuple_2i tup = std::make_tuple(gender, behavior);
 
         double discountAdjustedCost = Event::DiscountEventCost(
             cost_data[tup].cost, discount, person->GetCurrentTimestep());

--- a/tests/src/eventtests/BehaviorChangesTest.cpp
+++ b/tests/src/eventtests/BehaviorChangesTest.cpp
@@ -50,13 +50,13 @@ TEST_F(BehaviorChangesTest, BehaviorChanges) {
 
     // Cost Setup
     struct cost_util cost = {25.00, 0.5};
-    Utils::tuple_3i tup_3i = std::make_tuple(25, 0, 4);
-    std::unordered_map<Utils::tuple_3i, struct cost_util, Utils::key_hash_3i,
-                       Utils::key_equal_3i>
+    Utils::tuple_2i tup_2i = std::make_tuple(0, 4);
+    std::unordered_map<Utils::tuple_2i, struct cost_util, Utils::key_hash_2i,
+                       Utils::key_equal_2i>
         cstorage;
-    cstorage[tup_3i] = cost;
+    cstorage[tup_2i] = cost;
     ON_CALL(*event_dm, SelectCustomCallback(COST_QUERY, _, _, _))
-        .WillByDefault(DoAll(SetArg2ToUM_T3I_CU(&cstorage), Return(0)));
+        .WillByDefault(DoAll(SetArg2ToUM_T2I_CU(&cstorage), Return(0)));
 
     // Decider Setup
     ON_CALL(*decider, GetDecision(_)).WillByDefault(Return(2));


### PR DESCRIPTION
Realized the cost and utilities being pulled during the callback from the SQL were completely wrong in the Behavior Impacts. This produced the wrong utilities for everyone but the population that utilized some form of drug.