### PR TITLE
Linking Include Guard Hotfix

### DIFF
--- a/src/event/include/Linking.hpp
+++ b/src/event/include/Linking.hpp
@@ -4,11 +4,14 @@
 // Created: 2025-04-09                                                        //
 // Author: Dimitri Baptiste                                                   //
 // -----                                                                      //
-// Last Modified: 2025-04-15                                                  //
+// Last Modified: 2025-04-17                                                  //
 // Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
+
+#ifndef EVENT_LINKING_HPP_
+#define EVENT_LINKING_HPP_
 
 #include "Cost.hpp"
 #include "Event.hpp"
@@ -69,3 +72,4 @@ public:
     LinkingIMPL(std::shared_ptr<datamanagement::DataManagerBase> dm);
 };
 } // namespace event
+#endif


### PR DESCRIPTION
Add include guards for `Linking.hpp`