### PR TITLE
hotfix for initial cohort loading enums

### DIFF
--- a/include/hepce/utils/formatting.hpp
+++ b/include/hepce/utils/formatting.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-15                                                  //
+// Last Modified: 2025-05-21                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
@@ -88,7 +88,7 @@ ToLowerVector(const std::vector<std::string> &vec_str) {
 
 template <typename T>
 inline bool FindInVector(std::vector<T> searched, std::vector<T> queries) {
-    for (T &query : queries) {
+    for (const T &query : queries) {
         if (std::find(searched.begin(), searched.end(), query) !=
             searched.end()) {
             return true;

--- a/src/model/internals/simulation_internals.hpp
+++ b/src/model/internals/simulation_internals.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-12                                                  //
+// Last Modified: 2025-05-21                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
@@ -55,20 +55,35 @@ private:
     CreateEvent(std::string event_name,
                 datamanagement::ModelData &model_data) const;
 
+    inline std::string InitialCohortSQL(int N) const {
+        std::stringstream ss;
+        ss << "SELECT age_months, gender, drug_behavior, "
+              "time_last_active_drug_use, seropositivity, genotype_three, "
+              "fibrosis_state, identified_as_hcv_positive, link_state, "
+              "hcv_status, pregnancy_state ";
+        ss << "FROM init_cohort ";
+        ss << "ORDER BY id ";
+        ss << "LIMIT " << std::to_string(N) << ";";
+        return ss.str();
+    }
+
     static inline void PersonVecCallback(std::any &storage,
                                          const SQLite::Statement &stmt) {
         std::vector<data::PersonSelect> *temp_vec =
             std::any_cast<std::vector<data::PersonSelect>>(&storage);
         data::PersonSelect temp;
-        temp.sex << stmt.getColumn(0);
+        temp.sex = static_cast<data::Sex>(stmt.getColumn(0).getInt());
         temp.age = stmt.getColumn(1).getInt();
         temp.is_alive = stmt.getColumn(2).getInt();
         temp.boomer_classification = stmt.getColumn(3).getInt();
-        temp.death_reason << stmt.getColumn(4);
-        temp.drug_behavior << stmt.getColumn(5);
+        temp.death_reason =
+            static_cast<data::DeathReason>(stmt.getColumn(4).getInt());
+        temp.drug_behavior =
+            static_cast<data::Behavior>(stmt.getColumn(5).getInt());
         temp.time_last_active_drug_use = stmt.getColumn(6).getInt();
-        temp.hcv << stmt.getColumn(7);
-        temp.fibrosis_state << stmt.getColumn(8);
+        temp.hcv = static_cast<data::HCV>(stmt.getColumn(7).getInt());
+        temp.fibrosis_state =
+            static_cast<data::FibrosisState>(stmt.getColumn(8).getInt());
         temp.is_genotype_three = stmt.getColumn(9).getInt();
         temp.seropositive = stmt.getColumn(10).getInt();
         temp.time_hcv_changed = stmt.getColumn(11).getInt();
@@ -76,18 +91,20 @@ private:
         temp.times_hcv_infected = stmt.getColumn(13).getInt();
         temp.times_acute_cleared = stmt.getColumn(14).getInt();
         temp.svrs = stmt.getColumn(15).getInt();
-        temp.hiv << stmt.getColumn(16);
+        temp.hiv = static_cast<data::HIV>(stmt.getColumn(16).getInt());
         temp.time_hiv_changed = stmt.getColumn(17).getInt();
         temp.low_cd4_months_count = stmt.getColumn(18).getInt();
-        temp.hcc_state << stmt.getColumn(19);
+        temp.hcc_state =
+            static_cast<data::HCCState>(stmt.getColumn(19).getInt());
         temp.hcc_diagnosed = stmt.getColumn(20).getInt();
         temp.currently_overdosing = stmt.getColumn(21).getInt();
         temp.num_overdoses = stmt.getColumn(22).getInt();
-        temp.moud_state << stmt.getColumn(23);
+        temp.moud_state = static_cast<data::MOUD>(stmt.getColumn(23).getInt());
         temp.time_started_moud = stmt.getColumn(24).getInt();
         temp.current_moud_concurrent_months = stmt.getColumn(25).getInt();
         temp.total_moud_months = stmt.getColumn(26).getInt();
-        temp.pregnancy_state << stmt.getColumn(27);
+        temp.pregnancy_state =
+            static_cast<data::PregnancyState>(stmt.getColumn(27).getInt());
         temp.time_of_pregnancy_change = stmt.getColumn(28).getInt();
         temp.pregnancy_count = stmt.getColumn(29).getInt();
         temp.num_infants = stmt.getColumn(30).getInt();
@@ -95,16 +112,21 @@ private:
         temp.num_infant_hcv_exposures = stmt.getColumn(32).getInt();
         temp.num_infant_hcv_infections = stmt.getColumn(33).getInt();
         temp.num_infant_hcv_tests = stmt.getColumn(34).getInt();
-        temp.measured_fibrosis_state << stmt.getColumn(35);
+        temp.measured_fibrosis_state = static_cast<data::MeasuredFibrosisState>(
+            stmt.getColumn(35).getInt());
         temp.had_second_test = stmt.getColumn(36).getInt();
         temp.time_of_last_staging = stmt.getColumn(37).getInt();
-        temp.hcv_link_state << stmt.getColumn(38);
+        temp.hcv_link_state =
+            static_cast<data::LinkageState>(stmt.getColumn(38).getInt());
         temp.time_of_hcv_link_change = stmt.getColumn(39).getInt();
-        temp.hcv_link_type << stmt.getColumn(40);
+        temp.hcv_link_type =
+            static_cast<data::ScreeningType>(stmt.getColumn(40).getInt());
         temp.hcv_link_count = stmt.getColumn(41).getInt();
-        temp.hiv_link_state << stmt.getColumn(42);
+        temp.hiv_link_state =
+            static_cast<data::LinkageState>(stmt.getColumn(42).getInt());
         temp.time_of_hiv_link_change = stmt.getColumn(43).getInt();
-        temp.hiv_link_type << stmt.getColumn(44);
+        temp.hiv_link_type =
+            static_cast<data::ScreeningType>(stmt.getColumn(44).getInt());
         temp.hiv_link_count = stmt.getColumn(45).getInt();
         temp.time_of_last_hcv_screening = stmt.getColumn(46).getInt();
         temp.num_hcv_ab_tests = stmt.getColumn(47).getInt();
@@ -136,7 +158,7 @@ private:
         temp.treatment_utility = stmt.getColumn(73).getDouble();
         temp.background_utility = stmt.getColumn(74).getDouble();
         temp.hiv_utility = stmt.getColumn(75).getDouble();
-        temp_vec->push_back(temp);
+        temp_vec->emplace_back(temp);
     }
 
     static inline void InitCohortVecCallback(std::any &storage,
@@ -145,16 +167,21 @@ private:
             std::any_cast<std::vector<data::PersonSelect>>(&storage);
         data::PersonSelect temp;
         temp.age = stmt.getColumn(0).getInt();
-        temp.sex << stmt.getColumn(1);
-        temp.drug_behavior << stmt.getColumn(2);
+        temp.sex = static_cast<data::Sex>(stmt.getColumn(1).getInt());
+        temp.drug_behavior =
+            static_cast<data::Behavior>(stmt.getColumn(2).getInt());
         temp.time_last_active_drug_use = stmt.getColumn(3).getInt();
         temp.seropositive = stmt.getColumn(4).getInt();
         temp.is_genotype_three = stmt.getColumn(5).getInt();
-        temp.fibrosis_state << stmt.getColumn(6);
+        temp.fibrosis_state =
+            static_cast<data::FibrosisState>(stmt.getColumn(6).getInt());
         temp.hcv_identified = stmt.getColumn(7).getInt();
-        temp.hcv_link_state << stmt.getColumn(8);
-        temp.hcv << stmt.getColumn(9);
-        temp_vec->push_back(temp);
+        temp.hcv_link_state =
+            static_cast<data::LinkageState>(stmt.getColumn(8).getInt());
+        temp.hcv = static_cast<data::HCV>(stmt.getColumn(9).getInt());
+        temp.pregnancy_state =
+            static_cast<data::PregnancyState>(stmt.getColumn(10).getInt());
+        temp_vec->emplace_back(temp);
     }
 };
 } // namespace model


### PR DESCRIPTION
The real PR. Just a quick hotfix for the initial cohort loading. Issue was enums were not casting correctly so this adds the static_cast forced check in the loading functions.