### PR TITLE
[Improvements] Update README and source file headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,17 @@ These categories are further broken into discrete events:
 - [DataManagement](https://github.com/SyndemicsLab/DataManagement)
 - [GoogleTest/`gtest`](https://github.com/google/googletest) (optional, used
   for unit testing)
+- [Ninja](https://ninja-build.org)
+- [spdlog](https://github.com/gabime/spdlog)
+- [SQLiteCpp](https://github.com/SRombauts/SQLiteCpp)
 
 ### Unix-based Systems
 
+Ensure that you have [Ninja](https://ninja-build.org) available in your
+environment, then run the following commands.
+
 ```sh
 git clone git@github.com:SyndemicsLab/hep-ce
-scripts/build.sh
+cd hep-ce
+cmake --workflow --preset gcc-release
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ These categories are further broken into discrete events:
 ### Unix-based Systems
 
 ```sh
-git clone git@github.com:SyndemicsLab/HEPCESimulationv2
+git clone git@github.com:SyndemicsLab/hep-ce
 scripts/build.sh
 ```

--- a/extras/executable/exec.cpp
+++ b/extras/executable/exec.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: exec.cpp                                                             //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/extras/hepcepy/.gitkeep
+++ b/extras/hepcepy/.gitkeep
@@ -1,9 +1,0 @@
-/*
- * Filename: /home/matt/Repos/HEPCESimulationv2/extras/hepcepy/.gitkeep
- * Path: /home/matt/Repos/HEPCESimulationv2/extras/hepcepy
- * Created Date: Friday, May 2nd 2025, 10:21:09 am
- * Author: Matthew Carroll
- * 
- * Copyright (c) 2025 Syndemics Lab
- */
-

--- a/include/hepce/data/types.hpp
+++ b/include/hepce/data/types.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: types.hpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/data/writer.hpp
+++ b/include/hepce/data/writer.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: writer.hpp                                                           //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/all_events.hpp
+++ b/include/hepce/event/all_events.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: all_events.hpp                                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-07                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/base/aging.hpp
+++ b/include/hepce/event/base/aging.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: aging.hpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/base/base_events.hpp
+++ b/include/hepce/event/base/base_events.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: base_events.hpp                                                      //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/base/death.hpp
+++ b/include/hepce/event/base/death.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: death.hpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/behavior/behavior_changes.hpp
+++ b/include/hepce/event/behavior/behavior_changes.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: behavior_changes.hpp                                                 //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/behavior/behavior_events.hpp
+++ b/include/hepce/event/behavior/behavior_events.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: behavior_events.hpp                                                  //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/behavior/moud.hpp
+++ b/include/hepce/event/behavior/moud.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: moud.hpp                                                             //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/behavior/overdose.hpp
+++ b/include/hepce/event/behavior/overdose.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: overdose.hpp                                                         //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/behavior/pregnancy.hpp
+++ b/include/hepce/event/behavior/pregnancy.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: pregnancy.hpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/event.hpp
+++ b/include/hepce/event/event.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: event.hpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/fibrosis/fibrosis_events.hpp
+++ b/include/hepce/event/fibrosis/fibrosis_events.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: fibrosis_events.hpp                                                  //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/fibrosis/hcc.hpp
+++ b/include/hepce/event/fibrosis/hcc.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: hcc.hpp                                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/fibrosis/progression.hpp
+++ b/include/hepce/event/fibrosis/progression.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: progression.hpp                                                      //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/fibrosis/staging.hpp
+++ b/include/hepce/event/fibrosis/staging.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: staging.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hcv/clearance.hpp
+++ b/include/hepce/event/hcv/clearance.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: clearance.hpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hcv/hcv_events.hpp
+++ b/include/hepce/event/hcv/hcv_events.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: hcv_events.hpp                                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hcv/infection.hpp
+++ b/include/hepce/event/hcv/infection.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infections.hpp                                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hcv/linking.hpp
+++ b/include/hepce/event/hcv/linking.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hcv/screening.hpp
+++ b/include/hepce/event/hcv/screening.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening.hpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hcv/treatment.hpp
+++ b/include/hepce/event/hcv/treatment.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: treatment.hpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hcv/voluntary_relink.hpp
+++ b/include/hepce/event/hcv/voluntary_relink.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: voluntary_relink.hpp                                                 //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hiv/hiv_events.hpp
+++ b/include/hepce/event/hiv/hiv_events.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: hiv_events.hpp                                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hiv/infection.hpp
+++ b/include/hepce/event/hiv/infection.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infection.hpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hiv/linking.hpp
+++ b/include/hepce/event/hiv/linking.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hiv/screening.hpp
+++ b/include/hepce/event/hiv/screening.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening.hpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/event/hiv/treatment.hpp
+++ b/include/hepce/event/hiv/treatment.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: treatment.hpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/hepce.hpp
+++ b/include/hepce/hepce.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: hepce.hpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/model/costing.hpp
+++ b/include/hepce/model/costing.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: costing.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/model/person.hpp
+++ b/include/hepce/model/person.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: person.hpp                                                           //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/model/sampler.hpp
+++ b/include/hepce/model/sampler.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: sampler.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/model/simulation.hpp
+++ b/include/hepce/model/simulation.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: simulation.hpp                                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/model/utility.hpp
+++ b/include/hepce/model/utility.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: utility.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/utils/config.hpp
+++ b/include/hepce/utils/config.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: config.hpp                                                           //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/utils/formatting.hpp
+++ b/include/hepce/utils/formatting.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: formatting.hpp                                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/utils/logging.hpp
+++ b/include/hepce/utils/logging.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: logging.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/utils/math.hpp
+++ b/include/hepce/utils/math.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: math.hpp                                                             //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/utils/pair_hashing.hpp
+++ b/include/hepce/utils/pair_hashing.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: pair_hashing.hpp                                                     //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/include/hepce/version.hpp
+++ b/include/hepce/version.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: version.hpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/data/internals/writer_internals.hpp
+++ b/src/data/internals/writer_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: writer_internals.hpp                                                 //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/data/types.cpp
+++ b/src/data/types.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: types.cpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-30                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/data/writer.cpp
+++ b/src/data/writer.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: writer.cpp                                                           //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/base/aging.cpp
+++ b/src/event/base/aging.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: aging.cpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/base/death.cpp
+++ b/src/event/base/death.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: death.cpp                                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/base/internals/aging_internals.hpp
+++ b/src/event/base/internals/aging_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: aging_internals.hpp                                                  //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/base/internals/death_internals.hpp
+++ b/src/event/base/internals/death_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: death_internals.hpp                                                  //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/behavior_changes.cpp
+++ b/src/event/behavior/behavior_changes.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: behavior_changes.cpp                                                 //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-23                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/internals/behavior_changes_internals.hpp
+++ b/src/event/behavior/internals/behavior_changes_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: behavior_changes_internals.hpp                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/internals/moud_internals.hpp
+++ b/src/event/behavior/internals/moud_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: moud_internals.hpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/internals/overdose_internals.hpp
+++ b/src/event/behavior/internals/overdose_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: overdose_internals.hpp                                               //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/internals/pregnancy_internals.hpp
+++ b/src/event/behavior/internals/pregnancy_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: pregnancy_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/moud.cpp
+++ b/src/event/behavior/moud.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: moud.cpp                                                             //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-08                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/overdose.cpp
+++ b/src/event/behavior/overdose.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: overdose.cpp                                                         //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-08                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/behavior/pregnancy.cpp
+++ b/src/event/behavior/pregnancy.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: pregnancy.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-23                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/fibrosis/internals/hcc_internals.hpp
+++ b/src/event/fibrosis/internals/hcc_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: hcc_internals.hpp                                                    //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/fibrosis/internals/progression_internals.hpp
+++ b/src/event/fibrosis/internals/progression_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: progression_internals.hpp                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/fibrosis/internals/staging_internals.hpp
+++ b/src/event/fibrosis/internals/staging_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: staging_internals.hpp                                                //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/fibrosis/progression.cpp
+++ b/src/event/fibrosis/progression.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: progression.cpp                                                      //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-23                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/fibrosis/staging.cpp
+++ b/src/event/fibrosis/staging.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: staging.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-23                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/clearance.cpp
+++ b/src/event/hcv/clearance.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: clearance.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/infection.cpp
+++ b/src/event/hcv/infection.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infection.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/internals/clearance_internals.hpp
+++ b/src/event/hcv/internals/clearance_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: clearance_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/internals/infection_internals.hpp
+++ b/src/event/hcv/internals/infection_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infection_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/internals/linking_internals.hpp
+++ b/src/event/hcv/internals/linking_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking_internals.hpp                                                //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/internals/screening_internals.hpp
+++ b/src/event/hcv/internals/screening_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/internals/treatment_internals.hpp
+++ b/src/event/hcv/internals/treatment_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: treatment_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/internals/voluntary_relink_internals.hpp
+++ b/src/event/hcv/internals/voluntary_relink_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: voluntary_relink_internals.hpp                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/linking.cpp
+++ b/src/event/hcv/linking.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-23                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/screening.cpp
+++ b/src/event/hcv/screening.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/treatment.cpp
+++ b/src/event/hcv/treatment.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: treatment.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hcv/voluntary_relink.cpp
+++ b/src/event/hcv/voluntary_relink.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: voluntary_relink.cpp                                                 //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/infection.cpp
+++ b/src/event/hiv/infection.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infection.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/internals/infection_internals.hpp
+++ b/src/event/hiv/internals/infection_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infection_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/internals/linking_internals.hpp
+++ b/src/event/hiv/internals/linking_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking_internals.hpp                                                //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/internals/screening_internals.hpp
+++ b/src/event/hiv/internals/screening_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/internals/treatment_internals.hpp
+++ b/src/event/hiv/internals/treatment_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: treatment_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-21                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/linking.cpp
+++ b/src/event/hiv/linking.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-23                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/screening.cpp
+++ b/src/event/hiv/screening.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/hiv/treatment.cpp
+++ b/src/event/hiv/treatment.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: treatment.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-21                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/internals/event_internals.hpp
+++ b/src/event/internals/event_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: event_internals.hpp                                                  //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/internals/linking_internals.hpp
+++ b/src/event/internals/linking_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking_internals.hpp                                                //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening_internals.hpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/costing.cpp
+++ b/src/model/costing.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: costing.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-22                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/internals/costing_internals.hpp
+++ b/src/model/internals/costing_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: cost_internals.hpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/internals/person_internals.hpp
+++ b/src/model/internals/person_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: person_internals.hpp                                                 //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/internals/sampler_internals.hpp
+++ b/src/model/internals/sampler_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: sampler_internals.hpp                                                //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/internals/simulation_internals.hpp
+++ b/src/model/internals/simulation_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: simulation_internals.hpp                                             //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/internals/utility_internals.hpp
+++ b/src/model/internals/utility_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: utility_internals.hpp                                                //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/person.cpp
+++ b/src/model/person.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: person.cpp                                                           //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-21                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/sampler.cpp
+++ b/src/model/sampler.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: sampler.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-02                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/simulation.cpp
+++ b/src/model/simulation.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: simulation.cpp                                                       //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-22                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/model/utility.cpp
+++ b/src/model/utility.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: utility.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-30                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/utils/internals/logging_internals.hpp
+++ b/src/utils/internals/logging_internals.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: logging_internals.hpp                                                //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: logging.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/mocks/costing_mock.hpp
+++ b/tests/mocks/costing_mock.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: costing_mock.hpp                                                     //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-09                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/mocks/person_mock.hpp
+++ b/tests/mocks/person_mock.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: person_mock.hpp                                                      //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/mocks/sampler_mock.hpp
+++ b/tests/mocks/sampler_mock.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: sampler_mock.hpp                                                     //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/data/writer_test.cpp
+++ b/tests/src/data/writer_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: DataWriterTest.cpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-03-12                                                        //
 // Author: Dimitri Baptiste                                                   //
 // -----                                                                      //

--- a/tests/src/event/base/aging_test.cpp
+++ b/tests/src/event/base/aging_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: AgingTest.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/base/death_test.cpp
+++ b/tests/src/event/base/death_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: DeathTest.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/behavior/behavior_changes_test.cpp
+++ b/tests/src/event/behavior/behavior_changes_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: BehaviorChangesTest.cpp                                              //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/behavior/moud_test.cpp
+++ b/tests/src/event/behavior/moud_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: moud_test.cpp                                                        //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/behavior/overdose_test.cpp
+++ b/tests/src/event/behavior/overdose_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: overdose_test.cpp                                                    //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/behavior/pregnancy_test.cpp
+++ b/tests/src/event/behavior/pregnancy_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: pregnancy_test.cpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/fibrosis/progression_test.cpp
+++ b/tests/src/event/fibrosis/progression_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File:progression_test.cpp                                                  //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/fibrosis/staging_test.cpp
+++ b/tests/src/event/fibrosis/staging_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: staging_test.cpp                                                     //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hcv/clearance_test.cpp
+++ b/tests/src/event/hcv/clearance_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: clearance_test.cpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hcv/infection_test.cpp
+++ b/tests/src/event/hcv/infection_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infection_test.cpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hcv/linking_test.cpp
+++ b/tests/src/event/hcv/linking_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking_test.cpp                                                     //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hcv/screening_test.cpp
+++ b/tests/src/event/hcv/screening_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening_test.cpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hcv/voluntary_relink_test.cpp
+++ b/tests/src/event/hcv/voluntary_relink_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: voluntary_relink_test.cpp                                            //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hiv/infection_test.cpp
+++ b/tests/src/event/hiv/infection_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: infection_test.cpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hiv/linking_test.cpp
+++ b/tests/src/event/hiv/linking_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: linking_test.cpp                                                     //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/event/hiv/screening_test.cpp
+++ b/tests/src/event/hiv/screening_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: screening_test.cpp                                                   //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/model/person_test.cpp
+++ b/tests/src/model/person_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: person_test.cpp                                                      //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-09                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/model/simulation_test.cpp
+++ b/tests/src/model/simulation_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: SimTest.cpp                                                          //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created: 2023-09-13                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //

--- a/tests/src/utils/logging_test.cpp
+++ b/tests/src/utils/logging_test.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: test_logging.cpp                                                     //
-// Project: HEPCESimulationv2                                                 //
+// Project: hep-ce                                                            //
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //


### PR DESCRIPTION
Per the title, adding dependencies and current build instructions to the README and changing source file headers from references to the now-deprecated `HEPCESimulationv2` to `hep-ce`.