### PR TITLE
Hotfix: Treatment Limit

### DIFF
--- a/src/event/internals/treatment_internals.hpp
+++ b/src/event/internals/treatment_internals.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-20                                                  //
+// Last Modified: 2025-06-30                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
@@ -172,14 +172,14 @@ protected:
     /// @param
     /// @return
     bool IsEligible(const model::Person &person) const {
-        auto not_retreatment_restricted =
-            ((_treatment_limit >
-              person.GetTreatmentDetails(GetInfectionType()).num_starts) ||
-             _treatment_limit < 0);
+        auto too_many_treatments =
+            ((_treatment_limit <=
+              person.GetTreatmentDetails(GetInfectionType()).num_starts) &&
+             _treatment_limit > 0);
 
-        auto not_on_treatment = (!person.GetTreatmentDetails(GetInfectionType())
-                                      .initiated_treatment);
-        return (not_retreatment_restricted && not_on_treatment &&
+        auto on_treatment = (person.GetTreatmentDetails(GetInfectionType())
+                                 .initiated_treatment);
+        return (!too_many_treatments && !on_treatment &&
                 IsEligibleFibrosisStage(person) && IsEligibleBehavior(person) &&
                 IsEligiblePregnancy(person) &&
                 IsEligibleTimeLastActive(person) &&


### PR DESCRIPTION
This PR addresses a bug Sarah found during 2nd order logic testing for the HCV Treatment Cascade indicating too many people were being treated when a treatment limit was imposed. 

Bug:
1. Set Treatment Limit in `sim.conf` to be 1
2. See in `population.csv` that some people have more than 1 treatment

New:
1. Set Treatment Limit in `sim.conf` to be 1
2. See in `population.csv` that everyone has <= 1 treatment start.

**NOTE:** Per @s-janel, basic treatment and salvage treatments do not need to be separated so we only record a difference in the starts. Therefore: `num_hcv_treatments_completed` should be less than or equal to `treatment_starts` + `salvage_starts`. (edited per PR comment)