### PR TITLE
[Hotfix] Periodic Screening First Timestep

### DIFF
--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-18                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-11                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -62,9 +62,11 @@ public:
 
         bool do_periodic_screen =
             (GetInterventionType() == "periodic") &&
-            (GetTimeSince(person, person.GetScreeningDetails(GetInfectionType())
-                                      .time_of_last_screening) >=
-             GetScreeningPeriod());
+            ((GetTimeSince(person,
+                           person.GetScreeningDetails(GetInfectionType())
+                               .time_of_last_screening) >=
+              GetScreeningPeriod()) ||
+             person.GetCurrentTimestep() == 1);
 
         // If it is time to do a one-time intervention screen or periodic
         // screen, run an intervention screen

--- a/tests/src/event/hcv/screening_test.cpp
+++ b/tests/src/event/hcv/screening_test.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-05-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-10                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-11                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -146,14 +146,14 @@ TEST_F(HCVScreeningTest, InterventionScreen_NegativeRNA) {
     const std::string LOG_FILE = LOG_NAME + ".log";
     hepce::utils::CreateFileLogger(LOG_NAME, LOG_FILE);
 
-    screen.identified = true;
+    screen.ab_positive = true;
 
     EXPECT_CALL(mock_sampler, GetDecision(_))
-        .WillOnce(Return(0))
-        .WillOnce(Return(1));
+        .WillOnce(Return(0))  // Decision to screen
+        .WillOnce(Return(1)); // Test decision - negative
 
-    EXPECT_CALL(mock_person, GetScreeningDetails(_))
-        .Times(1)
+    EXPECT_CALL(mock_person, GetScreeningDetails(data::InfectionType::kHcv))
+        .Times(2) // once for `valid_screen` and again for antibody testing
         .WillRepeatedly(Return(screen));
     EXPECT_CALL(mock_person, GetHCVDetails())
         .Times(1)


### PR DESCRIPTION
- Fix periodic screening to screen on the first timestep, as intended
- Fix an issue in an intervention test where an if statement was branching correctly but for the wrong reason.