### PR TITLE
Hotfix/is eligible last time active bugs

### DIFF
--- a/src/event/internals/treatment_internals.hpp
+++ b/src/event/internals/treatment_internals.hpp
@@ -220,8 +220,10 @@ private:
     }
 
     bool IsEligibleTimeLastActive(const model::Person &person) const {
-        auto time = person.GetBehaviorDetails().time_last_active;
-        if (time == -1 || time > _eligibilities.time_since_last_use) {
+        auto time = person.GetCurrentTimestep() -
+            person.GetBehaviorDetails().time_last_active;
+        //auto time = person.GetBehaviorDetails().time_last_active;
+        if (time <= -1 || time > _eligibilities.time_since_last_use) {
             return true;
         }
         return false;

--- a/src/event/internals/treatment_internals.hpp
+++ b/src/event/internals/treatment_internals.hpp
@@ -220,9 +220,9 @@ private:
     }
 
     bool IsEligibleTimeLastActive(const model::Person &person) const {
-        auto time = person.GetCurrentTimestep() -
-                    person.GetBehaviorDetails().time_last_active;
-        if (time <= -1 || time > _eligibilities.time_since_last_use) {
+        auto time = person.GetBehaviorDetails().time_last_active;
+        auto time_diff = person.GetCurrentTimestep() - time;
+        if (time <= -1 || time_diff > _eligibilities.time_since_last_use) {
             return true;
         }
         return false;

--- a/src/event/internals/treatment_internals.hpp
+++ b/src/event/internals/treatment_internals.hpp
@@ -221,8 +221,7 @@ private:
 
     bool IsEligibleTimeLastActive(const model::Person &person) const {
         auto time = person.GetCurrentTimestep() -
-            person.GetBehaviorDetails().time_last_active;
-        //auto time = person.GetBehaviorDetails().time_last_active;
+                    person.GetBehaviorDetails().time_last_active;
         if (time <= -1 || time > _eligibilities.time_since_last_use) {
             return true;
         }

--- a/src/model/internals/person_internals.hpp
+++ b/src/model/internals/person_internals.hpp
@@ -328,6 +328,13 @@ private:
         }
         return mult;
     }
+
+    inline void SetBehaviorLastTimeActive(int tla) {
+        if (_behavior_details.time_last_active == _current_time) {
+            return;
+        }
+        _behavior_details.time_last_active = tla < -1 ? -1 : tla;
+    }
 };
 } // namespace model
 } // namespace hepce

--- a/src/model/person.cpp
+++ b/src/model/person.cpp
@@ -46,11 +46,7 @@ void PersonImpl::SetPersonDetails(const data::PersonSelect &storage) {
 
     // BehaviorDetails
     SetBehavior(storage.drug_behavior);
-    _behavior_details.time_last_active =
-        (storage.time_last_active_drug_use < -1)
-        ? -1
-        : storage.time_last_active_drug_use;
-    //_behavior_details.time_last_active = storage.time_last_active_drug_use;
+    SetBehaviorLastTimeActive(storage.time_last_active_drug_use);
 
     // HCVDetails
     _hcv_details.hcv = storage.hcv;

--- a/src/model/person.cpp
+++ b/src/model/person.cpp
@@ -46,7 +46,11 @@ void PersonImpl::SetPersonDetails(const data::PersonSelect &storage) {
 
     // BehaviorDetails
     SetBehavior(storage.drug_behavior);
-    _behavior_details.time_last_active = storage.time_last_active_drug_use;
+    _behavior_details.time_last_active =
+        (storage.time_last_active_drug_use < -1)
+        ? -1
+        : storage.time_last_active_drug_use;
+    //_behavior_details.time_last_active = storage.time_last_active_drug_use;
 
     // HCVDetails
     _hcv_details.hcv = storage.hcv;

--- a/tests/constants/config.hpp
+++ b/tests/constants/config.hpp
@@ -352,6 +352,116 @@ inline void BuildOverdoseSimConf(const std::string &name) {
     f.close();
 }
 
+inline void BuildEligibilitySimConf(const std::string &name) {
+    std::stringstream s;
+    s << "[simulation]" << std::endl
+      << "seed =" << std::endl
+      << "population_size = 100" << std::endl
+      << "events = Aging, BehaviorChanges, Clearance, FibrosisProgression, "
+         "HCVInfections, HCVScreening, HCVLinking, HCVTreatment, "
+         "HIVInfections, HIVScreening, HIVLinking, Overdose, Death"
+      << std::endl
+      << "duration = 60" << std::endl
+      << "start_time = 0" << std::endl
+      << "[mortality]" << std::endl
+      << "f4_infected = 0.000451633598615886" << std::endl
+      << "f4_uninfected = 0.0000271037696334409" << std::endl
+      << "decomp_infected = 0.01734776" << std::endl
+      << "decomp_uninfected = 0.005688756" << std::endl
+      << "[infection]" << std::endl
+      << std::endl
+      << "clearance_prob = 0.0489" << std::endl
+      << "genotype_three_prob = 0.153" << std::endl
+      << "[eligibility]" << std::endl
+      << "ineligible_drug_use =" << std::endl
+      << "ineligible_fibrosis_stages =" << std::endl
+      << "ineligible_time_former_threshold = 6" << std::endl
+      << "ineligible_time_since_linked =" << std::endl
+      << "[fibrosis]" << std::endl
+      << "f01 = 0.008877" << std::endl
+      << "f12 = 0.00681" << std::endl
+      << "f23 = 0.0097026" << std::endl
+      << "f34 = 0.0096201" << std::endl
+      << "f4d = 0.00558434922840212" << std::endl
+      << "add_cost_only_if_identified = false" << std::endl
+      << "[fibrosis_staging]" << std::endl
+      << "period = 12" << std::endl
+      << "test_one = fib4" << std::endl
+      << "test_one_cost = 0" << std::endl
+      << "test_two = fibroscan" << std::endl
+      << "test_two_cost = 140" << std::endl
+      << "multitest_result_method = latest" << std::endl
+      << "test_two_eligible_stages = f1,f2,f3" << std::endl
+      << "[screening]" << std::endl
+      << "intervention_type = one-time" << std::endl
+      << "period = 12" << std::endl
+      << "[screening_background_ab]" << std::endl
+      << "cost = 14.27" << std::endl
+      << "acute_sensitivity = 0.98" << std::endl
+      << "chronic_sensitivity = 0.98" << std::endl
+      << "specificity = 0.98" << std::endl
+      << "[screening_background_rna]" << std::endl
+      << "cost = 31.22" << std::endl
+      << "acute_sensitivity = 0.988" << std::endl
+      << "chronic_sensitivity = 0.988" << std::endl
+      << "specificity = 1.0" << std::endl
+      << "[screening_intervention_ab]" << std::endl
+      << "cost = 14.27" << std::endl
+      << "acute_sensitivity = 0.98" << std::endl
+      << "chronic_sensitivity = 0.98" << std::endl
+      << "specificity = 0.98" << std::endl
+      << "[screening_intervention_rna]" << std::endl
+      << "cost = 31.22" << std::endl
+      << "acute_sensitivity = 0.988" << std::endl
+      << "chronic_sensitivity = 0.988" << std::endl
+      << "specificity = 1.0" << std::endl
+      << "[linking]" << std::endl
+      << "intervention_cost = 0" << std::endl
+      << "voluntary_relinkage_probability = 0.001113" << std::endl
+      << "voluntary_relink_duration = 3" << std::endl
+      << "false_positive_test_cost = 442.39" << std::endl
+      << "recent_screen_multiplier = 1.1" << std::endl
+      << "recent_screen_cutoff = 0" << std::endl
+      << "[treatment]" << std::endl
+      << "treatment_limit = 5" << std::endl
+      << "treatment_cost = 12603.02" << std::endl
+      << "salvage_cost = 19332.50" << std::endl
+      << "treatment_utility = 0.99" << std::endl
+      << "tox_cost = 201.28" << std::endl
+      << "tox_utility = 0.21" << std::endl
+      << "[hiv_screening]" << std::endl
+      << "intervention_type = null" << std::endl
+      << "hiv_screening.period = 12" << std::endl
+      << "[hiv_screening_background]" << std::endl
+      << "ab_cost = 14.27" << std::endl
+      << "ab_sensitivity = 0.98" << std::endl
+      << "ab_specificity = 0.98" << std::endl
+      << "rna_cost = 31.22" << std::endl
+      << "rna_sensitivity = 0.988" << std::endl
+      << "rna_specificity = 1.0" << std::endl
+      << "[hiv_screening_intervention]" << std::endl
+      << "ab_cost = 14.27" << std::endl
+      << "ab_sensitivity = 0.98" << std::endl
+      << "ab_specificity = 0.98" << std::endl
+      << "rna_cost = 31.22" << std::endl
+      << "rna_sensitivity = 0.988" << std::endl
+      << "rna_specificity = 1.0" << std::endl
+      << "[hiv_linking]" << std::endl
+      << "intervention_cost = 100.00" << std::endl
+      << "false_positive_test_cost = 1800.00" << std::endl
+      << "recent_screen_multiplier = 2.0" << std::endl
+      << "recent_screen_cutoff = 2" << std::endl
+      << "[pregnancy]" << std::endl
+      << "multiple_delivery_probability = 0.03283" << std::endl
+      << "infant_hcv_tested_probability = 0.4" << std::endl
+      << "vertical_hcv_transition_probability = 0.08" << std::endl
+      << "[cost]" << std::endl
+      << "discounting_rate = 0.0025" << std::endl;
+
+    std::ofstream f(name);
+    f << s.str();
+    f.close();
+}
 } // namespace testing
 } // namespace hepce
 

--- a/tests/src/event/hcv/treatment_test.cpp
+++ b/tests/src/event/hcv/treatment_test.cpp
@@ -392,7 +392,8 @@ TEST_F(HCVTreatmentTest, PassesIsEligibleTimeLastUse) {
     ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(14));
     ON_CALL(mock_person, GetBehaviorDetails()).WillByDefault(Return(behaviors));
     EXPECT_CALL(mock_person, GetLinkageDetails(data::InfectionType::kHcv))
-    .Times(2).WillRepeatedly(Return(linkage));
+        .Times(2)
+        .WillRepeatedly(Return(linkage));
     EXPECT_CALL(mock_sampler, GetDecision({{0.0}})).WillOnce(Return(1));
     EXPECT_CALL(mock_sampler, GetDecision({{.92}})).WillOnce(Return(1));
 

--- a/tests/src/event/hcv/treatment_test.cpp
+++ b/tests/src/event/hcv/treatment_test.cpp
@@ -356,7 +356,6 @@ TEST_F(HCVTreatmentTest, Withdraw) {
     std::filesystem::remove(LOG_FILE);
 }
 
-// eligibility requirements
 TEST_F(HCVTreatmentTest, FailsIsEligibleTimeLastUse) {
     const std::string LOG_NAME = "FailsIsEligibleTimeLastUse";
     const std::string LOG_FILE = LOG_NAME + ".log";
@@ -369,14 +368,11 @@ TEST_F(HCVTreatmentTest, FailsIsEligibleTimeLastUse) {
     behaviors.time_last_active = 7;
     ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(12));
     ON_CALL(mock_person, GetBehaviorDetails()).WillByDefault(Return(behaviors));
-    EXPECT_CALL(mock_person, GetLinkageDetails(_)).Times(1)
-    .WillOnce(Return(linkage));
+    EXPECT_CALL(mock_person, GetLinkageDetails(_))
+        .Times(1)
+        .WillOnce(Return(linkage));
     EXPECT_CALL(mock_sampler, GetDecision({{0.0}})).WillOnce(Return(1));
 
-    //kNa pregnancy state means is -1, which is 0.0 probability
-    //fibrosis stage kF0 so we're eligible
-    //no behavior eligibilities, so we're eligible
-    //pregnancy is na (uses overloaded << operator) so eligible
     auto event = event::hcv::Treatment::Create(*model_data, LOG_NAME);
     event->Execute(mock_person, mock_sampler);
 
@@ -384,7 +380,7 @@ TEST_F(HCVTreatmentTest, FailsIsEligibleTimeLastUse) {
 }
 
 TEST_F(HCVTreatmentTest, PassesIsEligibleTimeLastUse) {
-    const std::string LOG_NAME = "IneligibleTimeLastUse";
+    const std::string LOG_NAME = "PassesIsEligibleTimeLastUse";
     const std::string LOG_FILE = LOG_NAME + ".log";
     hepce::utils::CreateFileLogger(LOG_NAME, LOG_FILE);
 
@@ -395,15 +391,12 @@ TEST_F(HCVTreatmentTest, PassesIsEligibleTimeLastUse) {
     behaviors.time_last_active = 7;
     ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(14));
     ON_CALL(mock_person, GetBehaviorDetails()).WillByDefault(Return(behaviors));
-    EXPECT_CALL(mock_person, GetLinkageDetails(_)).WillOnce(Return(linkage))
-    .WillOnce(Return(linkage));
+    EXPECT_CALL(mock_person, GetLinkageDetails(_))
+        .WillOnce(Return(linkage))
+        .WillOnce(Return(linkage));
     EXPECT_CALL(mock_sampler, GetDecision({{0.0}})).WillOnce(Return(1));
     EXPECT_CALL(mock_sampler, GetDecision({{.92}})).WillOnce(Return(1));
 
-    //kNa pregnancy state means is -1, which is 0.0 probability
-    //fibrosis stage kF0 so we're eligible
-    //no behavior eligibilities, so we're eligible
-    //pregnancy is na (uses overloaded << operator) so eligible
     auto event = event::hcv::Treatment::Create(*model_data, LOG_NAME);
     event->Execute(mock_person, mock_sampler);
 

--- a/tests/src/event/hcv/treatment_test.cpp
+++ b/tests/src/event/hcv/treatment_test.cpp
@@ -356,5 +356,59 @@ TEST_F(HCVTreatmentTest, Withdraw) {
     std::filesystem::remove(LOG_FILE);
 }
 
+// eligibility requirements
+TEST_F(HCVTreatmentTest, FailsIsEligibleTimeLastUse) {
+    const std::string LOG_NAME = "FailsIsEligibleTimeLastUse";
+    const std::string LOG_FILE = LOG_NAME + ".log";
+    hepce::utils::CreateFileLogger(LOG_NAME, LOG_FILE);
+
+    BuildEligibilitySimConf(test_conf);
+    model_data = datamanagement::ModelData::Create(test_conf);
+    model_data->AddSource(test_db);
+
+    behaviors.time_last_active = 7;
+    ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(12));
+    ON_CALL(mock_person, GetBehaviorDetails()).WillByDefault(Return(behaviors));
+    EXPECT_CALL(mock_person, GetLinkageDetails(_)).Times(1)
+    .WillOnce(Return(linkage));
+    EXPECT_CALL(mock_sampler, GetDecision({{0.0}})).WillOnce(Return(1));
+
+    //kNa pregnancy state means is -1, which is 0.0 probability
+    //fibrosis stage kF0 so we're eligible
+    //no behavior eligibilities, so we're eligible
+    //pregnancy is na (uses overloaded << operator) so eligible
+    auto event = event::hcv::Treatment::Create(*model_data, LOG_NAME);
+    event->Execute(mock_person, mock_sampler);
+
+    std::filesystem::remove(LOG_FILE);
+}
+
+TEST_F(HCVTreatmentTest, PassesIsEligibleTimeLastUse) {
+    const std::string LOG_NAME = "IneligibleTimeLastUse";
+    const std::string LOG_FILE = LOG_NAME + ".log";
+    hepce::utils::CreateFileLogger(LOG_NAME, LOG_FILE);
+
+    BuildEligibilitySimConf(test_conf);
+    model_data = datamanagement::ModelData::Create(test_conf);
+    model_data->AddSource(test_db);
+
+    behaviors.time_last_active = 7;
+    ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(14));
+    ON_CALL(mock_person, GetBehaviorDetails()).WillByDefault(Return(behaviors));
+    EXPECT_CALL(mock_person, GetLinkageDetails(_)).WillOnce(Return(linkage))
+    .WillOnce(Return(linkage));
+    EXPECT_CALL(mock_sampler, GetDecision({{0.0}})).WillOnce(Return(1));
+    EXPECT_CALL(mock_sampler, GetDecision({{.92}})).WillOnce(Return(1));
+
+    //kNa pregnancy state means is -1, which is 0.0 probability
+    //fibrosis stage kF0 so we're eligible
+    //no behavior eligibilities, so we're eligible
+    //pregnancy is na (uses overloaded << operator) so eligible
+    auto event = event::hcv::Treatment::Create(*model_data, LOG_NAME);
+    event->Execute(mock_person, mock_sampler);
+
+    std::filesystem::remove(LOG_FILE);
+}
+
 } // namespace testing
 } // namespace hepce

--- a/tests/src/event/hcv/treatment_test.cpp
+++ b/tests/src/event/hcv/treatment_test.cpp
@@ -368,7 +368,7 @@ TEST_F(HCVTreatmentTest, FailsIsEligibleTimeLastUse) {
     behaviors.time_last_active = 7;
     ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(12));
     ON_CALL(mock_person, GetBehaviorDetails()).WillByDefault(Return(behaviors));
-    EXPECT_CALL(mock_person, GetLinkageDetails(_))
+    EXPECT_CALL(mock_person, GetLinkageDetails(data::InfectionType::kHcv))
         .Times(1)
         .WillOnce(Return(linkage));
     EXPECT_CALL(mock_sampler, GetDecision({{0.0}})).WillOnce(Return(1));
@@ -391,9 +391,8 @@ TEST_F(HCVTreatmentTest, PassesIsEligibleTimeLastUse) {
     behaviors.time_last_active = 7;
     ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(14));
     ON_CALL(mock_person, GetBehaviorDetails()).WillByDefault(Return(behaviors));
-    EXPECT_CALL(mock_person, GetLinkageDetails(_))
-        .WillOnce(Return(linkage))
-        .WillOnce(Return(linkage));
+    EXPECT_CALL(mock_person, GetLinkageDetails(data::InfectionType::kHcv))
+    .Times(2).WillRepeatedly(Return(linkage));
     EXPECT_CALL(mock_sampler, GetDecision({{0.0}})).WillOnce(Return(1));
     EXPECT_CALL(mock_sampler, GetDecision({{.92}})).WillOnce(Return(1));
 


### PR DESCRIPTION
Summary
Addresses bug regarding undertreatment of hcv positive cohort without eligibility requirements. Corrects logic when checking if eligibility time since last use requirement is satisfied.

**old**
- in Person.SetBehaviorDetails, _behavior_details.last_time_active could be set to values less than -1
- in IsEligibleLastTimeActive, first condition checked that time == -1
- second condition checked that _behavior_details.last_time_active > eligibility time since last use requirement

**new**
- introduced function SetBehaviorTimeSinceLastUse:
    -_behavior_details.last_time_active will not overwrite previous value if that value was already set to _current_time (happens in SetBehavior)
    -  otherwise, when given values less than -1, _behavior_details.last_time_active will be set to -1
- IsEligibleLastTimeActive, first condition checks that time <= -1
- IsEligibleLastTimeActive, second condition checks elapsed time since last use > eligibility since last use requirement
- added tests to check that a person is/isn't eligible if they meet/don't meet eligibility time since last use requirements