### PR TITLE
sets identified to false after negative test

### DIFF
--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -325,12 +325,15 @@ private:
         if (valid_screen &&
             (!person.GetScreeningDetails(GetInfectionType()).ab_positive)) {
             if (!RunTest(person, type, data::ScreeningTest::kAb, sampler)) {
+                person.ClearDiagnosis(GetInfectionType());
                 return;
             }
         }
 
         if (RunTest(person, type, data::ScreeningTest::kRna, sampler)) {
             person.Diagnose(GetInfectionType());
+        } else {
+            person.ClearDiagnosis(GetInfectionType());
         }
     }
 };


### PR DESCRIPTION
People identified with HCV who take antibody or RNA tests that are (falsely) negative will no longer be identified as having HCV. Everyone that is HCV ab positive should have tested positive on both an ab and RNA test.