### PR TITLE
[Hotfix] Screening "over-identification"

### DIFF
--- a/include/hepce/model/person.hpp
+++ b/include/hepce/model/person.hpp
@@ -1,11 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: person.hpp                                                           //
 // Project: hep-ce                                                            //
-// Created Date: 2025-04-17                                                  //
+// Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-12                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-18                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -39,7 +39,7 @@ public:
     virtual void ClearHCV(bool is_acute = false) = 0;
     virtual void SetHCV(data::HCV hcv) = 0;
     virtual void Diagnose(data::InfectionType it) = 0;
-    virtual void ClearDiagnosis(data::InfectionType it) = 0;
+    virtual void ClearDiagnosis(data::InfectionType it, bool fp = false) = 0;
     virtual bool IsCirrhotic() const = 0;
     virtual void SetFibrosis(data::FibrosisState) = 0;
     virtual void AddSVR() = 0;

--- a/src/event/hcv/internals/linking_internals.hpp
+++ b/src/event/hcv/internals/linking_internals.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-06                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-18                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -42,7 +42,7 @@ private:
         if (person.GetHCVDetails().hcv != data::HCV::kNone) {
             return false;
         }
-        person.ClearDiagnosis(data::InfectionType::kHcv);
+        person.ClearDiagnosis(data::InfectionType::kHcv, true);
         AddFalsePositiveCost(person, GetEventCostCategory());
         return true;
     }

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-04-18                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-16                                                  //
+// Last Modified: 2025-07-18                                                  //
 // Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
@@ -315,15 +315,18 @@ private:
     /// @param person The Person undergoing an Intervention Screening
     inline void Screen(data::ScreeningType type, model::Person &person,
                        model::Sampler &sampler) {
-        // if person is intervention screening and not identified OR background screened
+        // if person is intervention screening and not identified OR background
+        // screened
         bool valid_screen =
             ((type == data::ScreeningType::kIntervention &&
               !person.GetScreeningDetails(GetInfectionType()).identified) ||
              type == data::ScreeningType::kBackground);
 
-        // if valid screen AND no positive history
-        if (valid_screen &&
-            (!person.GetScreeningDetails(GetInfectionType()).ab_positive)) {
+        if (!valid_screen) {
+            return;
+        }
+
+        if (!person.GetScreeningDetails(GetInfectionType()).ab_positive) {
             if (!RunTest(person, type, data::ScreeningTest::kAb, sampler)) {
                 person.ClearDiagnosis(GetInfectionType());
                 return;

--- a/src/model/internals/person_internals.hpp
+++ b/src/model/internals/person_internals.hpp
@@ -1,11 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 // File: person_internals.hpp                                                 //
 // Project: hep-ce                                                            //
-// Created Date: 2025-04-18                                                  //
+// Created Date: 2025-04-18                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-12                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-18                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -105,7 +105,11 @@ public:
         _screening_details[it].times_identified++;
         _screening_details[it].ab_positive = true;
     }
-    inline void ClearDiagnosis(data::InfectionType it) override {
+    inline void ClearDiagnosis(data::InfectionType it, bool fp) override {
+        // remove identification from count if false positive
+        if (fp) {
+            _screening_details[it].times_identified--;
+        }
         _screening_details[it].identified = false;
     }
 

--- a/src/model/person.cpp
+++ b/src/model/person.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-21                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-12                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-18                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,7 +109,8 @@ void PersonImpl::SetPersonDetails(const data::PersonSelect &storage) {
         storage.time_of_last_hcv_screening;
     _screening_details[it].num_ab_tests = storage.num_hcv_ab_tests;
     _screening_details[it].num_rna_tests = storage.num_hcv_rna_tests;
-    _screening_details[it].ab_positive = storage.hcv_antibody_positive;
+    _screening_details[it].ab_positive =
+        (storage.hcv_antibody_positive || storage.seropositive);
     _screening_details[it].identified = storage.hcv_identified;
     _screening_details[it].time_identified = storage.time_hcv_identified;
     _screening_details[it].times_identified = storage.times_hcv_identified;


### PR DESCRIPTION
Resolves issue due to over-identification during intervention screens
Also addresses over-counting of identifications due to false positives.

The change to `person.ab_positive` to be based on both `person.seropositive` AND `person.ab_positive` is due to technically redundant conditions. `seropositive` is a thus-far unused value that was intended to be, effectively, a "true" state for hcv infection history (something set upon one's first infection and never unset) but has thus far gone unused.

I plan to make changes to the person object soon, either removing `seropositive` entirely or going the opposite direction and treating it as "true" vs "measured" as we do with fibrosis states.