### PR TITLE
Hotfix/zero clearance

### DIFF
--- a/src/event/hcv/clearance.cpp
+++ b/src/event/hcv/clearance.cpp
@@ -62,9 +62,9 @@ void ClearanceImpl::LoadData(datamanagement::ModelData &model_data) {
         utils::GetDoubleFromConfig("infection.clearance_prob", model_data);
 
     if (_probability == -1) {
-        hepce::utils::LogInfo(GetLogName(),
-                              "Infection Clearance Probability is not found "
-                              "setting to default value of 25\% over 6 months");
+        hepce::utils::LogInfo(
+            GetLogName(), "Infection Clearance Probability is not found. "
+                          "setting to default value of 25\% over 6 months.");
         _probability =
             utils::RateToProbability(utils::ProbabilityToRate(0.25, 6));
     }

--- a/src/event/hcv/clearance.cpp
+++ b/src/event/hcv/clearance.cpp
@@ -62,9 +62,9 @@ void ClearanceImpl::LoadData(datamanagement::ModelData &model_data) {
         utils::GetDoubleFromConfig("infection.clearance_prob", model_data);
 
     if (_probability == -1) {
-        hepce::utils::LogInfo(
-            GetLogName(), "Infection Clearance Probability is not found "
-                          "setting to default value of 25\% over 6 months");
+        hepce::utils::LogInfo(GetLogName(),
+                              "Infection Clearance Probability is not found "
+                              "setting to default value of 25\% over 6 months");
         _probability =
             utils::RateToProbability(utils::ProbabilityToRate(0.25, 6));
     }

--- a/src/event/hcv/clearance.cpp
+++ b/src/event/hcv/clearance.cpp
@@ -61,10 +61,10 @@ void ClearanceImpl::LoadData(datamanagement::ModelData &model_data) {
     _probability =
         utils::GetDoubleFromConfig("infection.clearance_prob", model_data);
 
-    if (_probability == 0) {
+    if (_probability == -1) {
         hepce::utils::LogInfo(
-            GetLogName(), "Infection Clearance Probability is not found or "
-                          "0, setting to default value of 25\% over 6 months");
+            GetLogName(), "Infection Clearance Probability is not found "
+                          "setting to default value of 25\% over 6 months");
         _probability =
             utils::RateToProbability(utils::ProbabilityToRate(0.25, 6));
     }

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -325,12 +325,15 @@ private:
         if (valid_screen &&
             (!person.GetScreeningDetails(GetInfectionType()).ab_positive)) {
             if (!RunTest(person, type, data::ScreeningTest::kAb, sampler)) {
+                person.ClearDiagnosis(GetInfectionType());
                 return;
             }
         }
 
         if (RunTest(person, type, data::ScreeningTest::kRna, sampler)) {
             person.Diagnose(GetInfectionType());
+        } else {
+            person.ClearDiagnosis(GetInfectionType());
         }
     }
 };

--- a/tests/constants/config.hpp
+++ b/tests/constants/config.hpp
@@ -12,14 +12,29 @@
 #ifndef HEPCE_TESTS_CONSTANTS_CONFIG_HPP_
 #define HEPCE_TESTS_CONSTANTS_CONFIG_HPP_
 
-#include <hepce/utils/logging.hpp>
-
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace hepce {
 namespace testing {
+
+inline void BuildSimConf(const std::string &name,
+  std::unordered_map<std::string, std::vector<std::string>> config) {
+    std::stringstream ss;
+    for (auto& [section, keys] : config) {
+        ss << '[' << section << ']' << std::endl;
+        for (auto& k : keys) {
+            ss << k << std::endl;
+        }
+    }
+    std::ofstream f(name);
+    f << ss.str();
+    f.close();
+}
+
 inline void BuildSimConf(const std::string &name) {
     std::stringstream s;
     s << "[simulation]" << std::endl
@@ -465,60 +480,6 @@ inline void BuildEligibilitySimConf(const std::string &name) {
     f.close();
 }
 
-inline bool SetSimConfValue(std::string& file, const std::string& log,
-  const std::string& s, std::string val) {
-  int index = s.find('.');
-  std::string sec = s.substr(0, index);
-  sec.insert(0, 1, '[');
-  sec += ']';
-  std::string key = s.substr(index + 1);
-  key += " =";
-
-  std::ifstream fin(file);
-  if(!fin) {
-    hepce::utils::LogError(log, "Failed to open sim.conf for reading!");
-    return false;
-  }
-  std::string tmp;
-  std::vector<std::string> lines;
-  while (getline(fin, tmp)) {
-    lines.push_back(tmp);
-    if (tmp == sec) {
-        while(getline(fin, tmp)) {
-            if (!tmp.empty() && tmp.front() == '[') {
-                //key not found
-                std::string msg = "Failed to change sim.conf value -- ";
-                msg += s;
-                msg += " -- not found";
-                hepce::utils::LogError(log, msg);
-                fin.close();
-                return false;
-            }
-            auto key_len = key.size();
-            if (tmp.substr(0, key_len) == key) {
-              if (val != "") {
-                val.insert(0, 1, ' ');
-              }
-                tmp.replace(key_len, tmp.size() - key_len, val);
-                lines.push_back(tmp);
-                break;
-            }
-            lines.push_back(tmp);
-        }
-    }
-  }
-  fin.close();
-  std::ofstream fout(file, std::ios::trunc);
-  if(!fout) {
-    hepce::utils::LogError(log, "Failed to open sim.conf for writing!");
-    return false;
-  }
-  for (auto& l : lines) {
-    fout << l << std::endl;
-  }
-  fout.close();
-  return true;
-}
 } // namespace testing
 } // namespace hepce
 

--- a/tests/constants/config.hpp
+++ b/tests/constants/config.hpp
@@ -21,12 +21,13 @@
 namespace hepce {
 namespace testing {
 
-inline void BuildSimConf(const std::string &name,
-  std::unordered_map<std::string, std::vector<std::string>> config) {
+inline void
+BuildSimConf(const std::string &name,
+             std::unordered_map<std::string, std::vector<std::string>> config) {
     std::stringstream ss;
-    for (auto& [section, keys] : config) {
+    for (auto &[section, keys] : config) {
         ss << '[' << section << ']' << std::endl;
-        for (auto& k : keys) {
+        for (auto &k : keys) {
             ss << k << std::endl;
         }
     }

--- a/tests/constants/config.hpp
+++ b/tests/constants/config.hpp
@@ -12,6 +12,8 @@
 #ifndef HEPCE_TESTS_CONSTANTS_CONFIG_HPP_
 #define HEPCE_TESTS_CONSTANTS_CONFIG_HPP_
 
+#include <hepce/utils/logging.hpp>
+
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -461,6 +463,61 @@ inline void BuildEligibilitySimConf(const std::string &name) {
     std::ofstream f(name);
     f << s.str();
     f.close();
+}
+
+inline bool SetSimConfValue(std::string& file, const std::string& log,
+  const std::string& s, std::string val) {
+  int index = s.find('.');
+  std::string sec = s.substr(0, index);
+  sec.insert(0, 1, '[');
+  sec += ']';
+  std::string key = s.substr(index + 1);
+  key += " =";
+
+  std::ifstream fin(file);
+  if(!fin) {
+    hepce::utils::LogError(log, "Failed to open sim.conf for reading!");
+    return false;
+  }
+  std::string tmp;
+  std::vector<std::string> lines;
+  while (getline(fin, tmp)) {
+    lines.push_back(tmp);
+    if (tmp == sec) {
+        while(getline(fin, tmp)) {
+            if (!tmp.empty() && tmp.front() == '[') {
+                //key not found
+                std::string msg = "Failed to change sim.conf value -- ";
+                msg += s;
+                msg += " -- not found";
+                hepce::utils::LogError(log, msg);
+                fin.close();
+                return false;
+            }
+            auto key_len = key.size();
+            if (tmp.substr(0, key_len) == key) {
+              if (val != "") {
+                val.insert(0, 1, ' ');
+              }
+                tmp.replace(key_len, tmp.size() - key_len, val);
+                lines.push_back(tmp);
+                break;
+            }
+            lines.push_back(tmp);
+        }
+    }
+  }
+  fin.close();
+  std::ofstream fout(file, std::ios::trunc);
+  if(!fout) {
+    hepce::utils::LogError(log, "Failed to open sim.conf for writing!");
+    return false;
+  }
+  for (auto& l : lines) {
+    fout << l << std::endl;
+  }
+  fout.close();
+  return true;
 }
 } // namespace testing
 } // namespace hepce

--- a/tests/src/event/hcv/clearance_test.cpp
+++ b/tests/src/event/hcv/clearance_test.cpp
@@ -144,5 +144,25 @@ TEST_F(HCVClearanceTest, Clearance) {
 
     std::filesystem::remove(LOG_FILE);
 }
+
+TEST_F(HCVClearanceTest, ClearanceProbZero) {
+    const std::string LOG_NAME = "ClearanceProbZero";
+    const std::string LOG_FILE = LOG_NAME + ".log";
+    hepce::utils::CreateFileLogger(LOG_NAME, LOG_FILE);
+
+    ASSERT_TRUE(SetSimConfValue(test_conf, LOG_NAME,
+        "infection.clearance_prob", "0"));
+    model_data = datamanagement::ModelData::Create(test_conf, LOG_NAME);
+
+    hcv.hcv = data::HCV::kAcute;
+    EXPECT_CALL(mock_person, GetHCVDetails()).WillOnce(Return(hcv));
+    EXPECT_CALL(mock_sampler, GetDecision({{0, 1}})).WillOnce(Return(1));
+
+    auto event = event::hcv::Clearance::Create(*model_data, LOG_NAME);
+    event->Execute(mock_person, mock_sampler);
+
+    std::filesystem::remove(LOG_FILE);
+    std::fstream f(test_conf);
+}
 } // namespace testing
 } // namespace hepce

--- a/tests/src/event/hcv/clearance_test.cpp
+++ b/tests/src/event/hcv/clearance_test.cpp
@@ -45,6 +45,7 @@ protected:
     NiceMock<MockPerson> mock_person;
     MockSampler mock_sampler;
     std::string test_conf = "sim.conf";
+    std::unordered_map<std::string, std::vector<std::string>> config;
     std::unique_ptr<datamanagement::ModelData> model_data;
     data::BehaviorDetails behaviors = {data::Behavior::kInjection, 0};
     data::HCVDetails hcv = {data::HCV::kNone,
@@ -150,8 +151,9 @@ TEST_F(HCVClearanceTest, ClearanceProbZero) {
     const std::string LOG_FILE = LOG_NAME + ".log";
     hepce::utils::CreateFileLogger(LOG_NAME, LOG_FILE);
 
-    ASSERT_TRUE(SetSimConfValue(test_conf, LOG_NAME,
-        "infection.clearance_prob", "0"));
+    config = {{"infection", {"clearance_prob = 0"}}};
+
+    BuildSimConf(test_conf, config);
     model_data = datamanagement::ModelData::Create(test_conf, LOG_NAME);
 
     hcv.hcv = data::HCV::kAcute;
@@ -162,7 +164,7 @@ TEST_F(HCVClearanceTest, ClearanceProbZero) {
     event->Execute(mock_person, mock_sampler);
 
     std::filesystem::remove(LOG_FILE);
-    std::fstream f(test_conf);
 }
+
 } // namespace testing
 } // namespace hepce

--- a/tests/src/event/hcv/screening_test.cpp
+++ b/tests/src/event/hcv/screening_test.cpp
@@ -225,6 +225,8 @@ TEST_F(HCVScreeningTest, Identified_NegativeABTest) {
     EXPECT_CALL(mock_person, Screen(infection_type, data::ScreeningTest::kAb,
                                     screen.screen_type))
         .Times(1);
+    EXPECT_CALL(mock_person, AddCost(14.27, _, model::CostCategory::kScreening))
+        .Times(1);
     EXPECT_CALL(mock_sampler, GetDecision({{.98}})).WillOnce(Return(1));
     EXPECT_CALL(mock_person, ClearDiagnosis(infection_type)).Times(1);
 

--- a/tests/src/event/hcv/screening_test.cpp
+++ b/tests/src/event/hcv/screening_test.cpp
@@ -72,8 +72,12 @@ protected:
                          "VALUES (25, 1, 4, -1, 0, 0.02, 1, 0.3);",
                          "INSERT INTO screening_and_linkage "
                          "VALUES (25, 1, 4, 1, 0, 0.03, 1, 0.4);",
+                         "INSERT INTO screening_and_linkage "
+                         "VALUES (26, 1, 4, -1, 1, 1, 0, 0);",
                          "INSERT INTO antibody_testing "
-                         "VALUES (25, 4, 1.0);"}});
+                         "VALUES (25, 4, 1.0);",
+                         "INSERT INTO antibody_testing "
+                         "VALUES (26, 4, 1.0);"}});
         BuildSimConf(test_conf);
         discounted_cost = utils::Discount(370.75, 0.0025, 1, false);
         discounted_life = utils::Discount(1, 0.0025, 1, false);
@@ -193,6 +197,36 @@ TEST_F(HCVScreeningTest, InterventionScreen_PositiveRNA) {
     EXPECT_CALL(mock_person, AddCost(31.22, _, model::CostCategory::kScreening))
         .Times(1);
     EXPECT_CALL(mock_person, Diagnose(_)).Times(1);
+
+    auto event = event::hcv::Screening::Create(*model_data, LOG_NAME);
+    event->Execute(mock_person, mock_sampler);
+    std::filesystem::remove(LOG_FILE);
+}
+
+TEST_F(HCVScreeningTest, Identified_NegativeABTest) {
+    const std::string LOG_NAME = "Identified_NegativeABTest";
+    const std::string LOG_FILE = LOG_NAME + ".log";
+    hepce::utils::CreateFileLogger(LOG_NAME, LOG_FILE);
+
+    screen.identified = true;
+    screen.screen_type = data::ScreeningType::kBackground;
+    auto infection_type = data::InfectionType::kHcv;
+    hcv.hcv = data::HCV::kChronic;
+
+    // to force background rather than intervention screen
+    ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(2));
+
+    ON_CALL(mock_person, GetAge()).WillByDefault(Return(26 * 12));
+    EXPECT_CALL(mock_sampler, GetDecision({{1.0}}))
+        .WillOnce(Return(0));
+    ON_CALL(mock_person, GetScreeningDetails(infection_type))
+        .WillByDefault(Return(screen));
+    
+    ON_CALL(mock_person, GetHCVDetails()).WillByDefault(Return(hcv));
+    EXPECT_CALL(mock_person, Screen(infection_type, data::ScreeningTest::kAb,
+        screen.screen_type)).Times(1);
+    EXPECT_CALL(mock_sampler, GetDecision({{.98}})).WillOnce(Return(1));
+    EXPECT_CALL(mock_person, ClearDiagnosis(infection_type)).Times(1);
 
     auto event = event::hcv::Screening::Create(*model_data, LOG_NAME);
     event->Execute(mock_person, mock_sampler);

--- a/tests/src/event/hcv/screening_test.cpp
+++ b/tests/src/event/hcv/screening_test.cpp
@@ -217,14 +217,14 @@ TEST_F(HCVScreeningTest, Identified_NegativeABTest) {
     ON_CALL(mock_person, GetCurrentTimestep()).WillByDefault(Return(2));
 
     ON_CALL(mock_person, GetAge()).WillByDefault(Return(26 * 12));
-    EXPECT_CALL(mock_sampler, GetDecision({{1.0}}))
-        .WillOnce(Return(0));
+    EXPECT_CALL(mock_sampler, GetDecision({{1.0}})).WillOnce(Return(0));
     ON_CALL(mock_person, GetScreeningDetails(infection_type))
         .WillByDefault(Return(screen));
-    
+
     ON_CALL(mock_person, GetHCVDetails()).WillByDefault(Return(hcv));
     EXPECT_CALL(mock_person, Screen(infection_type, data::ScreeningTest::kAb,
-        screen.screen_type)).Times(1);
+                                    screen.screen_type))
+        .Times(1);
     EXPECT_CALL(mock_sampler, GetDecision({{.98}})).WillOnce(Return(1));
     EXPECT_CALL(mock_person, ClearDiagnosis(infection_type)).Times(1);
 


### PR DESCRIPTION
Summary:
- new BuildSimConf function
- will use 0 as probability when clearance_prob set to 0
- test that ClearDiagnosis is called for HCV false negatives
- test that 0 is used as probability when clearance_prob set to 0

Old:
- Needed to make new build functions to set up new configs in tests, required creating the entire sim.conf file
- When clearance_prob was 0, the default value was used instead of 0

New:
- New BuildSimConf takes an unordered_map with only the config settings required for a given test
- Zero will be used as the probability if clearance_prob is set to 0