### PR TITLE
Linking exp decay

### DIFF
--- a/extras/examples/sim.conf
+++ b/extras/examples/sim.conf
@@ -269,6 +269,11 @@ voluntary_relink_duration = 240
 # Type: float
 false_positive_test_cost = 515.79
 
+# The mode by which linking probability scales
+# Type: string
+# Possible values: multiplier, exponential
+scaling_type = exponential
+
 # The number of months to apply `recent_screen_multiplier` to the rate of
 # linking to care
 # Type: int
@@ -278,11 +283,6 @@ recent_screen_cutoff = 0
 # `recent_screen_cutoff` months since screening.
 # Type: float
 recent_screen_multiplier = 1.0
-
-# The mode by which linking probability decays
-# Type: string
-# Possible values: multiplier, exponential
-decay_type = exponential
 
 # This section governs HCV treatment
 [treatment]

--- a/src/event/hcv/linking.cpp
+++ b/src/event/hcv/linking.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-23                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-15                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-22                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -46,11 +46,14 @@ void LinkingImpl::LoadData(datamanagement::ModelData &model_data) {
         utils::GetDoubleFromConfig("linking.intervention_cost", model_data));
     SetFalsePositiveCost(utils::GetDoubleFromConfig(
         "linking.false_positive_test_cost", model_data));
-    SetRecentScreenMultiplier(utils::GetDoubleFromConfig(
-        "linking.recent_screen_multiplier", model_data));
-    SetRecentScreenCutoff(
-        utils::GetIntFromConfig("linking.recent_screen_cutoff", model_data));
-    SetDecayType(utils::GetStringFromConfig("linking.decay_type", model_data));
+    SetScalingType(
+        utils::GetStringFromConfig("linking.scaling_type", model_data));
+    if (GetScalingType() == "multiplier") {
+        SetRecentScreenMultiplier(utils::GetDoubleFromConfig(
+            "linking.recent_screen_multiplier", model_data));
+        SetRecentScreenCutoff(utils::GetIntFromConfig(
+            "linking.recent_screen_cutoff", model_data));
+    }
 }
 } // namespace hcv
 } // namespace event

--- a/src/model/internals/person_internals.hpp
+++ b/src/model/internals/person_internals.hpp
@@ -5,7 +5,7 @@
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
 // Last Modified: 2025-07-22                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -335,13 +335,6 @@ private:
             mult *= kv.second;
         }
         return mult;
-    }
-
-    inline void SetBehaviorLastTimeActive(int tla) {
-        if (_behavior_details.time_last_active == _current_time) {
-            return;
-        }
-        _behavior_details.time_last_active = tla < -1 ? -1 : tla;
     }
 };
 } // namespace model

--- a/src/model/person.cpp
+++ b/src/model/person.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-21                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-18                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-22                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -45,8 +45,8 @@ void PersonImpl::SetPersonDetails(const data::PersonSelect &storage) {
     SetDeathReason(storage.death_reason);
 
     // BehaviorDetails
+    _behavior_details.time_last_active = storage.time_last_active_drug_use;
     SetBehavior(storage.drug_behavior);
-    SetBehaviorLastTimeActive(storage.time_last_active_drug_use);
 
     // HCVDetails
     _hcv_details.hcv = storage.hcv;

--- a/tests/constants/config.hpp
+++ b/tests/constants/config.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-23                                                  //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-09                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-22                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -104,9 +104,9 @@ inline void BuildSimConf(const std::string &name) {
       << "voluntary_relinkage_probability = 0.001113" << std::endl
       << "voluntary_relink_duration = 3" << std::endl
       << "false_positive_test_cost = 442.39" << std::endl
+      << "scaling_type = multiplier" << std::endl
       << "recent_screen_multiplier = 1.1" << std::endl
       << "recent_screen_cutoff = 0" << std::endl
-      << "decay_type = multiplier" << std::endl
       << "[treatment]" << std::endl
       << "treatment_limit = 5" << std::endl
       << "treatment_cost = 12603.02" << std::endl

--- a/tests/src/event/hcv/linking_test.cpp
+++ b/tests/src/event/hcv/linking_test.cpp
@@ -5,7 +5,7 @@
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
 // Last Modified: 2025-07-22                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -249,7 +249,7 @@ TEST_F(HCVLinkingTest, LinkRateExpDecay) {
 
     config = {{"linking",
                {"recent_screen_cutoff = 10", "recent_screen_multiplier = 1.0",
-                "decay_type = exponential"}}};
+                "scaling_type = exponential"}}};
 
     BuildSimConf(test_conf, config);
     model_data = datamanagement::ModelData::Create(test_conf, LOG_NAME);
@@ -282,7 +282,7 @@ TEST_F(HCVLinkingTest, LinkRateMultiplier) {
 
     config = {{"linking",
                {"recent_screen_cutoff = 10", "recent_screen_multiplier = 0.5",
-                "decay_type = multiplier"}}};
+                "scaling_type = multiplier"}}};
 
     BuildSimConf(test_conf, config);
     model_data = datamanagement::ModelData::Create(test_conf, LOG_NAME);

--- a/tests/src/model/person_test.cpp
+++ b/tests/src/model/person_test.cpp
@@ -5,7 +5,7 @@
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
 // Last Modified: 2025-07-22                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -433,9 +433,9 @@ TEST_F(PersonTest, MakePopulationRow) {
 
 TEST_F(PersonTest, LastTimeActiveLessThanNegOne) {
     PersonSelect person_select;
-    person_select.time_last_active_drug_use = -3;
+    person_select.time_last_active_drug_use = -6;
     person->SetPersonDetails(person_select);
-    EXPECT_EQ(person->GetBehaviorDetails().time_last_active, -1);
+    EXPECT_EQ(person->GetBehaviorDetails().time_last_active, -6);
 }
 } // namespace testing
 } // namespace hepce


### PR DESCRIPTION
Summary:
- Added the functionality for the user to configure the model to use either "multiplier" or "exponential" modes of decay.
- Edited the sim.conf example to reflect this.
- Added 2 Linking tests, one for checking the probability of linking with exponential enabled, and one for checking the probability with multiplier enabled.
- Added a test to check that when time_last_active is set to -1 when inputs for time_last_active_drug_use are <= -1.

Old:
- A single multiplier was used to scale linking probability for those who had recently been screened. Within the recent cutoff window the rate will be L' = L * multiplier.

New:
- sim.conf contains a field named "decay_type" which takes "exponential" or "multiplier".
- If "exponential" is used, the rate decreases by the equation L' = L * e^(-t)
- If "multiplier" is used the original multiplier feature will be used.
- If left blank, an error will be logged and the rate will not be adjusted.
- A test for checking the probability in exponential mode
- A test for checking the probability in multiplier mode
- An unrelated test for checking that time_last_active is set to -1 for input value of time_last_active_drug_use less than -1.