### PR TITLE
[Bugfix] Address bugs from validation

### DIFF
--- a/extras/examples/sim.conf
+++ b/extras/examples/sim.conf
@@ -118,6 +118,11 @@ f34 = 0.0096201
 # Type: float
 f4d = 0.00558434922840212
 
+# Whether cost should be accumulated for liver disease only when identified by
+# the healthcare system
+# Type: boolean
+add_cost_only_if_identified = false
+
 # This section governs quantities related to clinical staging of liver fibrosis
 [fibrosis_staging]
 # The number of months between fibrosis staging for the HCV-infected
@@ -166,6 +171,10 @@ intervention_type = periodic
 # is set to `periodic`
 # Type: int
 period = 12
+
+# A multiplier on the rate of screening for those labeled as baby boomers
+# Type: float
+seropositivity_multiplier_boomer = 1.0
 
 # This section governs the characteristics of background antibody screening
 [screening_background_ab]

--- a/extras/executable/exec.cpp
+++ b/extras/executable/exec.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-30                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-25                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,6 +77,7 @@ int main(int argc, char *argv[]) {
         std::filesystem::path dbfile = input_dir / "inputs.db";
         std::filesystem::path config = input_dir / "sim.conf";
         std::filesystem::path popfile = output_dir / "population.csv";
+        std::filesystem::path costfile = output_dir / "categorized_costs.csv";
 
         std::filesystem::path log_file = output_dir / "hepce.log";
         std::string log_name = "hepce-task-" + std::to_string(i);
@@ -94,6 +95,8 @@ int main(int argc, char *argv[]) {
             hepce::data::Writer::Create(output_dir.string(), log_name);
         writer->WritePopulation(population, popfile.string(),
                                 hepce::data::OutputType::kFile);
+        writer->WriteCostsByCategory(population, costfile.string(),
+                                     hepce::data::OutputType::kFile);
     }
 
     return 0;

--- a/include/hepce/data/writer.hpp
+++ b/include/hepce/data/writer.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-08                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-24                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -25,6 +25,11 @@ class Writer {
 public:
     virtual ~Writer() = default;
     virtual std::string WritePopulation(
+        const std::vector<std::unique_ptr<model::Person>> &population,
+        const std::string &filename, const OutputType output_type,
+        std::vector<int> ids = {}) = 0;
+
+    virtual std::string WriteCostsByCategory(
         const std::vector<std::unique_ptr<model::Person>> &population,
         const std::string &filename, const OutputType output_type,
         std::vector<int> ids = {}) = 0;

--- a/src/data/internals/writer_internals.hpp
+++ b/src/data/internals/writer_internals.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-12                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-24                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -22,6 +22,10 @@ public:
                const std::string &log_name = "console");
     ~WriterImpl() = default;
     std::string WritePopulation(
+        const std::vector<std::unique_ptr<model::Person>> &population,
+        const std::string &filename, const OutputType output_type,
+        std::vector<int> ids = {}) override;
+    std::string WriteCostsByCategory(
         const std::vector<std::unique_ptr<model::Person>> &population,
         const std::string &filename, const OutputType output_type,
         std::vector<int> ids = {}) override;

--- a/src/data/writer.cpp
+++ b/src/data/writer.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-12                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-25                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <numeric>
 
+#include <hepce/model/costing.hpp>
 #include <hepce/model/person.hpp>
 #include <hepce/utils/logging.hpp>
 
@@ -56,6 +57,48 @@ std::string WriterImpl::WritePopulation(
     for (int i = 0; i < population.size(); ++i) {
         csvStream << ids[i] << "," << population[i]->MakePopulationRow()
                   << std::endl;
+    }
+    csvStream.close();
+    return "success";
+}
+
+std::string WriterImpl::WriteCostsByCategory(
+    const std::vector<std::unique_ptr<model::Person>> &population,
+    const std::string &filename, const OutputType output_type,
+    std::vector<int> ids) {
+    if (ids.empty()) {
+        ids.resize(population.size());
+        std::iota(ids.begin(), ids.end(), 1);
+    }
+    std::filesystem::path path = filename;
+    std::ofstream csvStream;
+    csvStream.open(path, std::ofstream::out);
+    if (!csvStream) {
+        hepce::utils::LogError(GetLogName(),
+                               "Unable to open CSV Stream to write!");
+        return "";
+    }
+    csvStream << "id,"
+              << "misc,discount_misc,behavior,discount_behavior,screening,"
+              << "discount_screening,linking,discount_linking,staging,"
+              << "discount_staging,liver,discount_liver,treatment,"
+              << "discount_treatment,background,discount_background,"
+              << "hiv,discount_hiv" << std::endl;
+    for (int i = 0; i < population.size(); ++i) {
+        csvStream << ids[i] << ",";
+        const auto &person_costs = population[i]->GetCosts();
+        for (int j = 0;
+             j < static_cast<int>(hepce::model::CostCategory::kCount); ++j) {
+            const auto &category_cost =
+                person_costs.at(static_cast<hepce::model::CostCategory>(j));
+            csvStream << category_cost.first << "," << category_cost.second;
+            if (static_cast<hepce::model::CostCategory>(j + 1) ==
+                hepce::model::CostCategory::kCount) {
+                break;
+            }
+            csvStream << ",";
+        }
+        csvStream << std::endl;
     }
     csvStream.close();
     return "success";

--- a/src/event/fibrosis/internals/progression_internals.hpp
+++ b/src/event/fibrosis/internals/progression_internals.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-18                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-05                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-25                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,7 +48,7 @@ public:
     void LoadData(datamanagement::ModelData &model_data) override;
 
 private:
-    bool _add_cost_data = false;
+    bool _add_if_identified = false;
     progression_probabilities _probabilities;
     costutilmap_t _cost_data;
 

--- a/src/event/fibrosis/progression.cpp
+++ b/src/event/fibrosis/progression.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-23                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-06-18                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-07-25                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,13 +60,15 @@ void ProgressionImpl::Execute(model::Person &person, model::Sampler &sampler) {
         person.SetFibrosis(fs);
     }
 
+    AddProgressionUtility(person);
     // insert Person's liver-related disease cost (taking the highest
     // fibrosis state) only if the person is identified as infected
-    if (_add_cost_data &&
-        person.GetScreeningDetails(data::InfectionType::kHcv).identified) {
-        AddProgressionCost(person);
+    if (_add_if_identified) {
+        if (!person.GetScreeningDetails(data::InfectionType::kHcv).identified) {
+            return;
+        }
     }
-    AddProgressionUtility(person);
+    AddProgressionCost(person);
 }
 
 void ProgressionImpl::LoadData(datamanagement::ModelData &model_data) {
@@ -79,7 +81,7 @@ void ProgressionImpl::LoadData(datamanagement::ModelData &model_data) {
                       utils::GetDoubleFromConfig("fibrosis.f34", model_data),
                       utils::GetDoubleFromConfig("fibrosis.f4d", model_data)};
 
-    _add_cost_data = utils::GetBoolFromConfig(
+    _add_if_identified = utils::GetBoolFromConfig(
         "fibrosis.add_cost_only_if_identified", model_data);
 
     std::any storage = costutilmap_t{};

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-04-18                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-21                                                  //
+// Last Modified: 2025-07-25                                                  //
 // Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
@@ -199,7 +199,14 @@ private:
             probability = _probability[tup].intervention;
         }
         if (person.IsBoomer()) {
-            probability *= _seropositivity_boomer_multiplier;
+            // there is no need to scale the probability up if it is already 1.
+            // it is also outside the domain of ln(1-prob), needed by
+            // `ProbabilityToRate()`
+            if (probability < 1.0) {
+                probability = utils::RateToProbability(
+                    utils::ProbabilityToRate(probability) *
+                    _seropositivity_boomer_multiplier);
+            }
         }
         return probability;
     }


### PR DESCRIPTION
No liver costs were being accumulated due to the way that `_add_cost_data` was being checked.
This PR resolves the behavior of this variable and renames it to better match its functionality.

An untouched value, `seropositivity_boomer_multiplier` has also been adjusted and documented.

To better address bugs of this type, I've also added a function to `writer` that creates a file with costs broken down by category. I hope to make that an optional functionality in the executable, but that might require adding optional runtime flags to the executable, which I'm not yet ready to do.