### PR TITLE
Feature/track false negatives

### DIFF
--- a/include/hepce/data/types.hpp
+++ b/include/hepce/data/types.hpp
@@ -65,9 +65,10 @@ POPULATION_HEADERS(bool pregnancy = false, bool hcc = false,
         headers << "never,-1,0,";
     }
     // ScreeningDetails
-    headers << "time_of_last_hcv_screening,num_hcv_ab_tests,num_hcv_rna_tests,"
-               "hcv_antibody_positive,hcv_identified,time_hcv_identified,num_"
-               "hcv_identifications,hcv_screening_type,";
+    headers
+        << "time_of_last_hcv_screening,num_hcv_ab_tests,num_hcv_rna_tests,"
+           "hcv_antibody_positive,hcv_identified,time_hcv_identified,num_"
+           "hcv_identifications,hcv_screening_type,num_hcv_false_negatives,";
     if (hiv) {
         headers
             << "time_of_last_hiv_screening,num_hiv_ab_tests,num_hiv_rna_tests,"
@@ -376,6 +377,7 @@ struct ScreeningDetails {
     int time_identified = -1;
     int times_identified = 0;
     ScreeningType screen_type = ScreeningType::kNa;
+    int num_false_negatives = 0;
 };
 std::ostream &operator<<(std::ostream &os, ScreeningDetails const &sdet);
 
@@ -481,6 +483,7 @@ struct PersonSelect {
     int hcv_identified = false;
     int time_hcv_identified = -1;
     int times_hcv_identified = 0;
+    int num_hcv_false_negatives = 0;
     // HIV
     int time_of_last_hiv_screening = -1;
     int num_hiv_ab_tests = 0;

--- a/include/hepce/data/types.hpp
+++ b/include/hepce/data/types.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-23                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/hepce/model/person.hpp
+++ b/include/hepce/model/person.hpp
@@ -44,6 +44,7 @@ public:
     virtual bool IsCirrhotic() const = 0;
     virtual void SetFibrosis(data::FibrosisState) = 0;
     virtual void AddSVR() = 0;
+    virtual void AddFalseNegative(data::InfectionType it) = 0;
 
     // Screening
     virtual data::ScreeningDetails

--- a/include/hepce/model/person.hpp
+++ b/include/hepce/model/person.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-23                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/data/writer.cpp
+++ b/src/data/writer.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-25                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-18                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-25                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -337,9 +337,9 @@ private:
         if (!person.GetScreeningDetails(GetInfectionType()).ab_positive) {
             if (!RunTest(person, type, data::ScreeningTest::kAb, sampler) &&
                 person.GetHCVDetails().hcv != data::HCV::kNone) {
-                    person.AddFalseNegative(GetInfectionType());
-                    person.ClearDiagnosis(GetInfectionType());
-                    return;
+                person.AddFalseNegative(GetInfectionType());
+                person.ClearDiagnosis(GetInfectionType());
+                return;
             }
         }
 

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -335,9 +335,11 @@ private:
         }
 
         if (!person.GetScreeningDetails(GetInfectionType()).ab_positive) {
-            if (!RunTest(person, type, data::ScreeningTest::kAb, sampler)) {
-                person.ClearDiagnosis(GetInfectionType());
-                return;
+            if (!RunTest(person, type, data::ScreeningTest::kAb, sampler) &&
+                person.GetHCVDetails().hcv != data::HCV::kNone) {
+                    person.AddFalseNegative(GetInfectionType());
+                    person.ClearDiagnosis(GetInfectionType());
+                    return;
             }
         }
 
@@ -345,7 +347,8 @@ private:
             if (!identified) {
                 person.Diagnose(GetInfectionType());
             }
-        } else {
+        } else if (person.GetHCVDetails().hcv != data::HCV::kNone) {
+            person.AddFalseNegative(GetInfectionType());
             person.ClearDiagnosis(GetInfectionType());
         }
     }

--- a/src/event/internals/screening_internals.hpp
+++ b/src/event/internals/screening_internals.hpp
@@ -334,22 +334,22 @@ private:
             return;
         }
 
-        if (!person.GetScreeningDetails(GetInfectionType()).ab_positive) {
-            if (!RunTest(person, type, data::ScreeningTest::kAb, sampler) &&
-                person.GetHCVDetails().hcv != data::HCV::kNone) {
+        if (!person.GetScreeningDetails(GetInfectionType()).ab_positive &&
+            !RunTest(person, type, data::ScreeningTest::kAb, sampler)) {
+            if (person.GetHCVDetails().hcv != data::HCV::kNone) {
                 person.AddFalseNegative(GetInfectionType());
-                person.ClearDiagnosis(GetInfectionType());
-                return;
             }
+            person.ClearDiagnosis(GetInfectionType());
+            return;
         }
 
-        if (RunTest(person, type, data::ScreeningTest::kRna, sampler)) {
-            if (!identified) {
-                person.Diagnose(GetInfectionType());
+        if (!RunTest(person, type, data::ScreeningTest::kRna, sampler)) {
+            if (person.GetHCVDetails().hcv != data::HCV::kNone) {
+                person.AddFalseNegative(GetInfectionType());
             }
-        } else if (person.GetHCVDetails().hcv != data::HCV::kNone) {
-            person.AddFalseNegative(GetInfectionType());
             person.ClearDiagnosis(GetInfectionType());
+        } else if (!identified) {
+            person.Diagnose(GetInfectionType());
         }
     }
 };

--- a/src/model/internals/person_internals.hpp
+++ b/src/model/internals/person_internals.hpp
@@ -116,6 +116,9 @@ public:
             _screening_details[it].ab_positive = false;
         }
     }
+    inline void AddFalseNegative(data::InfectionType it) override {
+        _screening_details[it].num_false_negatives++;
+    }
 
     void Screen(data::InfectionType it, data::ScreeningTest test,
                 data::ScreeningType type) override {

--- a/src/model/internals/person_internals.hpp
+++ b/src/model/internals/person_internals.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-18                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-23                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/model/person.cpp
+++ b/src/model/person.cpp
@@ -115,6 +115,8 @@ void PersonImpl::SetPersonDetails(const data::PersonSelect &storage) {
     _screening_details[it].time_identified = storage.time_hcv_identified;
     _screening_details[it].times_identified = storage.times_hcv_identified;
     _screening_details[it].screen_type = storage.hcv_link_type;
+    _screening_details[it].num_false_negatives =
+        storage.num_hcv_false_negatives;
 
     // TreatmentDetails
     _treatment_details[it].initiated_treatment =
@@ -357,7 +359,8 @@ std::string PersonImpl::MakePopulationRow() const {
                        << std::boolalpha << hcvsd.identified << ","
                        << hcvsd.time_identified << ","
                        << hcvsd.times_identified << ","
-                       << hcvsd.screen_type << ",";
+                       << hcvsd.screen_type << ","
+                       << hcvsd.num_false_negatives << ",";
         const auto &hivsd = _screening_details.at(data::InfectionType::kHiv);
         population_row << hivsd.time_of_last_screening << ","
                        << hivsd.num_ab_tests << ","

--- a/src/model/person.cpp
+++ b/src/model/person.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-21                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-23                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/mocks/person_mock.hpp
+++ b/tests/mocks/person_mock.hpp
@@ -50,6 +50,7 @@ public:
                  data::ScreeningType type),
                 (override));
     MOCK_METHOD(void, GiveSecondStagingTest, (), (override));
+    MOCK_METHOD(void, AddFalseNegative, (data::InfectionType it), (override));
 
     // Linking
     MOCK_METHOD(data::LinkageDetails, GetLinkageDetails,

--- a/tests/mocks/person_mock.hpp
+++ b/tests/mocks/person_mock.hpp
@@ -4,8 +4,8 @@
 // Created: 2025-01-06                                                        //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-22                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/src/event/hcv/screening_test.cpp
+++ b/tests/src/event/hcv/screening_test.cpp
@@ -160,9 +160,7 @@ TEST_F(HCVScreeningTest, InterventionScreen_NegativeRNA) {
     EXPECT_CALL(mock_person, GetScreeningDetails(data::InfectionType::kHcv))
         .Times(2) // once for `valid_screen` and again for antibody testing
         .WillRepeatedly(Return(screen));
-    EXPECT_CALL(mock_person, GetHCVDetails())
-        .Times(1)
-        .WillRepeatedly(Return(hcv));
+    ON_CALL(mock_person, GetHCVDetails()).WillByDefault(Return(hcv));
     EXPECT_CALL(mock_person, Screen(_, data::ScreeningTest::kRna,
                                     data::ScreeningType::kIntervention))
         .Times(1);
@@ -229,6 +227,7 @@ TEST_F(HCVScreeningTest, Identified_NegativeABTest) {
     EXPECT_CALL(mock_person, AddCost(14.27, _, model::CostCategory::kScreening))
         .Times(1);
     EXPECT_CALL(mock_sampler, GetDecision({{.98}})).WillOnce(Return(1));
+    EXPECT_CALL(mock_person, AddFalseNegative(TYPE)).Times(1);
     EXPECT_CALL(mock_person, ClearDiagnosis(TYPE)).Times(1);
 
     auto event = event::hcv::Screening::Create(*model_data, LOG_NAME);

--- a/tests/src/event/hcv/screening_test.cpp
+++ b/tests/src/event/hcv/screening_test.cpp
@@ -160,7 +160,9 @@ TEST_F(HCVScreeningTest, InterventionScreen_NegativeRNA) {
     EXPECT_CALL(mock_person, GetScreeningDetails(data::InfectionType::kHcv))
         .Times(2) // once for `valid_screen` and again for antibody testing
         .WillRepeatedly(Return(screen));
-    ON_CALL(mock_person, GetHCVDetails()).WillByDefault(Return(hcv));
+    EXPECT_CALL(mock_person, GetHCVDetails())
+        .Times(2)
+        .WillRepeatedly(Return(hcv));
     EXPECT_CALL(mock_person, Screen(_, data::ScreeningTest::kRna,
                                     data::ScreeningType::kIntervention))
         .Times(1);
@@ -308,6 +310,5 @@ TEST_F(HCVScreeningTest, RedundantIdentification) {
     event->Execute(mock_person, mock_sampler);
     std::filesystem::remove(LOG_FILE);
 }
-
 } // namespace testing
 } // namespace hepce

--- a/tests/src/model/person_test.cpp
+++ b/tests/src/model/person_test.cpp
@@ -428,7 +428,7 @@ TEST_F(PersonTest, Accumulate) {
 // Not sure how to test this, its a dump of the data into a CSV string
 TEST_F(PersonTest, MakePopulationRow) {
     std::string str = person->MakePopulationRow();
-    EXPECT_EQ(utils::SplitToVecT<std::string>(str, ',').size(), 86);
+    EXPECT_EQ(utils::SplitToVecT<std::string>(str, ',').size(), 87);
 }
 
 TEST_F(PersonTest, LastTimeActiveLessThanNegOne) {

--- a/tests/src/model/person_test.cpp
+++ b/tests/src/model/person_test.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-05-09                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-07-23                                                  //
-// Modified By: Dimitri Baptiste                                              //
+// Last Modified: 2025-07-29                                                  //
+// Modified By: Andrew Clark                                                  //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Summary:
Added a member to `ScreeningDetails` to track false negatives. Changed the logic in screening_intenerals.hpp to only call `ClearDiagnosis` and `AddFalseNegative` when a test returns false and they're actually infected.

Old:
- false negatives weren't tracked
- `ClearDiagnosis` was called whenever there was a negative result on a test

New:
- `ClearDiagnosis` should only be called when a test returns false and the person is infected
- `num_false_negatives` is incremented by the `AddFalseNegative` function whenever this happens
- num_hcv_false_negatives added to the list of headers used in population and updated in writer.cpp
- tests updated to accommodate this change

Another note:
Not every false negative leads to an extra identification. If a person gets consecutive false negatives, or if they die before they test positive again, they won't tack on the extra identification.