### PR TITLE
[Hotfix] Simulation - No Seed Provided

### DIFF
--- a/include/hepce/utils/math.hpp
+++ b/include/hepce/utils/math.hpp
@@ -55,7 +55,7 @@ inline double Discount(double value, double discount_rate, double timestep,
 
 /// @brief Retrieves the current time since epoch in milliseconds as an integer.
 /// @return The current time in milliseconds
-inline int GetTimeInt() {
+inline int GetCurrentTimeInMilliseconds() {
     const std::chrono::time_point<std::chrono::steady_clock> current_time =
         std::chrono::steady_clock::now();
     return static_cast<int>(

--- a/include/hepce/utils/math.hpp
+++ b/include/hepce/utils/math.hpp
@@ -4,16 +4,18 @@
 // Created Date: 2025-04-17                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-05-02                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2025-08-04                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
 #ifndef HEPCE_UTILS_MATH_HPP_
 #define HEPCE_UTILS_MATH_HPP_
 
+#include <chrono>
 #include <cmath>
 #include <stdexcept>
+
 namespace hepce {
 namespace utils {
 /// @brief Convert Probability to Rate
@@ -49,6 +51,17 @@ inline double Discount(double value, double discount_rate, double timestep,
     discount_rate = annual ? discount_rate / 12 : discount_rate;
     double denominator = std::pow(1 + discount_rate, timestep);
     return value / denominator;
+}
+
+/// @brief Retrieves the current time since epoch in milliseconds as an integer.
+/// @return The current time in milliseconds
+inline int GetTimeInt() {
+    const std::chrono::time_point<std::chrono::steady_clock> current_time =
+        std::chrono::steady_clock::now();
+    return static_cast<int>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            current_time.time_since_epoch())
+            .count());
 }
 } // namespace utils
 } // namespace hepce

--- a/src/model/simulation.cpp
+++ b/src/model/simulation.cpp
@@ -36,7 +36,7 @@ HepceImpl::HepceImpl(datamanagement::ModelData &model_data,
     _duration = utils::GetIntFromConfig("simulation.duration", model_data);
     _sim_seed = utils::GetIntFromConfig("simulation.seed", model_data);
     if (_sim_seed < 0) {
-        _sim_seed = utils::GetTimeInt();
+        _sim_seed = utils::GetCurrentTimeInMilliseconds();
         std::stringstream msg;
         msg << "No seed or negative seed provided in `sim.conf`. Using "
                "generated seed value: "

--- a/src/model/simulation.cpp
+++ b/src/model/simulation.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-04-22                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-08-01                                                  //
+// Last Modified: 2025-08-04                                                  //
 // Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
@@ -16,6 +16,7 @@
 #include <hepce/utils/config.hpp>
 #include <hepce/utils/formatting.hpp>
 #include <hepce/utils/logging.hpp>
+#include <hepce/utils/math.hpp>
 
 #include "internals/simulation_internals.hpp"
 
@@ -34,6 +35,14 @@ HepceImpl::HepceImpl(datamanagement::ModelData &model_data,
     : _log_name(log_name) {
     _duration = utils::GetIntFromConfig("simulation.duration", model_data);
     _sim_seed = utils::GetIntFromConfig("simulation.seed", model_data);
+    if (_sim_seed < 0) {
+        _sim_seed = utils::GetTimeInt();
+        std::stringstream msg;
+        msg << "No seed or negative seed provided in `sim.conf`. Using "
+               "generated seed value: "
+            << _sim_seed << ".";
+        hepce::utils::LogWarning(GetLogName(), msg.str());
+    }
 }
 
 void HepceImpl::Run(


### PR DESCRIPTION
Fix simulation behavior to correctly use a seed based on epoch time, when no seed has been provided.

Uses the current time since epoch as an integer.
One thing to note is that the epoch isn't universally defined in C++, so maybe if we don't explicitly set the seed to be unsigned, we might get unusual negative values for the seed. I think the pRNG handles negative seeds fine (it has some kind of operation to make them usable) but I think it's more intuitive to put reasonable conditions on what seeds users can specify.