### PR TITLE
[Hotfix] Old Age Postpartum Handling

### DIFF
--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -112,6 +112,7 @@ are named as follows:
 - `link_states`
 - `lost_to_follow_up`
 - `moud`
+- `population`
 - `pregnancy`
 - `pregnancy_states`
 - `screening_and_linkage`

--- a/src/event/internals/pregnancy_internals.hpp
+++ b/src/event/internals/pregnancy_internals.hpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-18                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-04-03                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2026-06-10                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
@@ -69,7 +69,7 @@ private:
             (ps == data::PregnancyState::kRestrictedPostpartum) ||
             (ps == data::PregnancyState::kYearOnePostpartum) ||
             (ps == data::PregnancyState::kYearTwoPostpartum);
-        ;
+
         return (too_old && (!pregnant && !rpostpartum));
     }
 

--- a/src/event/pregnancy.cpp
+++ b/src/event/pregnancy.cpp
@@ -39,10 +39,8 @@ void Pregnancy::Execute(model::Person &person, const model::Sampler &sampler) {
 
     ProgressPostpartum(person);
 
-    // person's current pregnancy state
-    data::PregnancyState ps = person.GetPregnancyDetails().pregnancy_state;
-
-    if (ps == data::PregnancyState::kPregnant) {
+    if (person.GetPregnancyDetails().pregnancy_state ==
+        data::PregnancyState::kPregnant) {
         if (GetTimeSince(
                 person,
                 person.GetPregnancyDetails().time_of_pregnancy_change) >= 9) {
@@ -51,9 +49,9 @@ void Pregnancy::Execute(model::Person &person, const model::Sampler &sampler) {
         return;
     }
 
-    if ((ps == data::PregnancyState::kRestrictedPostpartum) ||
-        (ps == data::PregnancyState::kYearOnePostpartum) ||
-        (ps == data::PregnancyState::kYearTwoPostpartum)) {
+    // filter out people who are postpartum past age 45 because they cannot
+    // get pregnant anymore (according to the model)
+    if (person.GetAge() > 540) {
         return;
     };
 

--- a/src/event/pregnancy.cpp
+++ b/src/event/pregnancy.cpp
@@ -4,8 +4,8 @@
 // Created Date: 2025-04-23                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-03-20                                                  //
-// Modified By: Matthew Carroll                                               //
+// Last Modified: 2026-06-10                                                  //
+// Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,6 +48,12 @@ void Pregnancy::Execute(model::Person &person, const model::Sampler &sampler) {
         }
         return;
     }
+
+    if ((ps == data::PregnancyState::kRestrictedPostpartum) ||
+        (ps == data::PregnancyState::kYearOnePostpartum) ||
+        (ps == data::PregnancyState::kYearTwoPostpartum)) {
+        return;
+    };
 
     double prob =
         _pregnancy_data[static_cast<int>(person.GetAge() / 12.0)].pregnant;

--- a/src/event/pregnancy.cpp
+++ b/src/event/pregnancy.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-04-23                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-06-10                                                  //
+// Last Modified: 2026-06-11                                                  //
 // Modified By: Dimitri Baptiste                                              //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -39,8 +39,10 @@ void Pregnancy::Execute(model::Person &person, const model::Sampler &sampler) {
 
     ProgressPostpartum(person);
 
-    if (person.GetPregnancyDetails().pregnancy_state ==
-        data::PregnancyState::kPregnant) {
+    // person's current pregnancy state
+    data::PregnancyState ps = person.GetPregnancyDetails().pregnancy_state;
+
+    if (ps == data::PregnancyState::kPregnant) {
         if (GetTimeSince(
                 person,
                 person.GetPregnancyDetails().time_of_pregnancy_change) >= 9) {

--- a/tests/src/event/behavior/pregnancy_test.cpp
+++ b/tests/src/event/behavior/pregnancy_test.cpp
@@ -148,7 +148,6 @@ TEST_F(PregnancyTest, ProgressesPostpartumToYearTwoWhenThresholdMet) {
     EXPECT_CALL(mock_person,
                 SetPregnancyState(data::PregnancyState::kYearTwoPostpartum))
         .Times(1);
-    EXPECT_CALL(mock_sampler, GetDecision(_)).WillOnce(Return(0));
     EXPECT_CALL(mock_person, Impregnate()).Times(0);
 
     event->Execute(mock_person, mock_sampler);
@@ -200,7 +199,6 @@ TEST_F(PregnancyTest, RestrictedPostpartumProgressesToYearOneAfterWindow) {
     EXPECT_CALL(mock_person,
                 SetPregnancyState(data::PregnancyState::kYearOnePostpartum))
         .Times(1);
-    EXPECT_CALL(mock_sampler, GetDecision(_)).WillOnce(Return(0));
     EXPECT_CALL(mock_person, Impregnate()).Times(0);
 
     event->Execute(mock_person, mock_sampler);
@@ -219,7 +217,6 @@ TEST_F(PregnancyTest, YearTwoPostpartumEndsAtTwoYears) {
     ASSERT_NE(event, nullptr);
 
     EXPECT_CALL(mock_person, EndPostpartum()).Times(1);
-    EXPECT_CALL(mock_sampler, GetDecision(_)).WillOnce(Return(0));
     EXPECT_CALL(mock_person, Impregnate()).Times(0);
 
     event->Execute(mock_person, mock_sampler);
@@ -271,6 +268,22 @@ TEST_F(PregnancyTest, ChronicMotherTwinBirthAddsExposuresAndBirths) {
 
     event->Execute(mock_person, mock_sampler);
 }
+
+TEST_F(PregnancyTest, PostpartumDoesNotRollImpregnation) {
+    pregnancy.pregnancy_state = data::PregnancyState::kYearOnePostpartum;
+    pregnancy.time_of_pregnancy_change = 2;
+    ON_CALL(mock_person, GetPregnancyDetails())
+        .WillByDefault(Return(pregnancy));
+
+    data::Inputs inputs(test_conf, test_db);
+    auto event = event::EventFactory::CreateEvent("Pregnancy", inputs,
+                                                  "PostpartumNoImpregnation");
+    ASSERT_NE(event, nullptr);
+
+    EXPECT_CALL(mock_person, Impregnate()).Times(0);
+
+    event->Execute(mock_person, mock_sampler);
+};
 
 TEST_F(PregnancyTest, MissingPregnancyTableFallsBackToZeroProbability) {
     ExecuteQueries(test_db, {"DROP TABLE IF EXISTS pregnancy;"});

--- a/tests/src/event/behavior/pregnancy_test.cpp
+++ b/tests/src/event/behavior/pregnancy_test.cpp
@@ -148,6 +148,7 @@ TEST_F(PregnancyTest, ProgressesPostpartumToYearTwoWhenThresholdMet) {
     EXPECT_CALL(mock_person,
                 SetPregnancyState(data::PregnancyState::kYearTwoPostpartum))
         .Times(1);
+    EXPECT_CALL(mock_sampler, GetDecision(_)).WillOnce(Return(0));
     EXPECT_CALL(mock_person, Impregnate()).Times(0);
 
     event->Execute(mock_person, mock_sampler);
@@ -199,6 +200,7 @@ TEST_F(PregnancyTest, RestrictedPostpartumProgressesToYearOneAfterWindow) {
     EXPECT_CALL(mock_person,
                 SetPregnancyState(data::PregnancyState::kYearOnePostpartum))
         .Times(1);
+    EXPECT_CALL(mock_sampler, GetDecision(_)).WillOnce(Return(0));
     EXPECT_CALL(mock_person, Impregnate()).Times(0);
 
     event->Execute(mock_person, mock_sampler);
@@ -217,6 +219,7 @@ TEST_F(PregnancyTest, YearTwoPostpartumEndsAtTwoYears) {
     ASSERT_NE(event, nullptr);
 
     EXPECT_CALL(mock_person, EndPostpartum()).Times(1);
+    EXPECT_CALL(mock_sampler, GetDecision(_)).WillOnce(Return(0));
     EXPECT_CALL(mock_person, Impregnate()).Times(0);
 
     event->Execute(mock_person, mock_sampler);
@@ -269,7 +272,8 @@ TEST_F(PregnancyTest, ChronicMotherTwinBirthAddsExposuresAndBirths) {
     event->Execute(mock_person, mock_sampler);
 }
 
-TEST_F(PregnancyTest, PostpartumDoesNotRollImpregnation) {
+TEST_F(PregnancyTest, OldAgePostpartumDoesNotRollImpregnation) {
+    ON_CALL(mock_person, GetAge()).WillByDefault(Return(541));
     pregnancy.pregnancy_state = data::PregnancyState::kYearOnePostpartum;
     pregnancy.time_of_pregnancy_change = 2;
     ON_CALL(mock_person, GetPregnancyDetails())
@@ -280,6 +284,7 @@ TEST_F(PregnancyTest, PostpartumDoesNotRollImpregnation) {
                                                   "PostpartumNoImpregnation");
     ASSERT_NE(event, nullptr);
 
+    EXPECT_CALL(mock_sampler, GetDecision(_)).Times(0);
     EXPECT_CALL(mock_person, Impregnate()).Times(0);
 
     event->Execute(mock_person, mock_sampler);


### PR DESCRIPTION
## What does this PR do?
This PR makes it impossible for pregnant people who are too old to get pregnant again from re-triggering pregnancy, fixing a minor bug in the model (which likely didn't affect model outcomes because the probability of pregnancy for those ages should be zero in the data).

## What Wrike task is this associated with?
**N/A**, impromptu bug fix

## Checklist before merging
<!--
Please fill in the checkboxes ([X]) to indicate that you addressed each of these
items when filling out this comment.
-->
- [X] If adding a core feature, I've added related tests.
- [X] This is part of a [product update](https://www.chameleon.io/blog/product-updates), and I've added an explanation of what is different to the changelog. **N/A**
